### PR TITLE
specify which MSH format: Gmsh's

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ e.g.,
  * [Exodus](https://cubit.sandia.gov/public/13.2/help_manual/WebHelp/finite_element_model/exodus/block_specification.htm)
  * [H5M](https://trac.mcs.anl.gov/projects/ITAPS/wiki/MOAB/h5m)
  * [Medit](https://people.sc.fsu.edu/~jburkardt/data/medit/medit.html)
- * [MSH](http://geuz.org/gmsh/doc/texinfo/gmsh.html#File-formats)
+ * [Gmsh](http://gmsh.info)'s [MSH](http://gmsh.info/doc/texinfo/gmsh.html#File-formats)
  * [OFF](http://segeval.cs.princeton.edu/public/off_format.html)
  * [PERMAS](http://www.intes.de)
  * [VTK](http://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf)


### PR DESCRIPTION
#77 reported confusion of MSH with a similarly named format used by ANSYS Fluent.  The link points to Gmsh, but here's a more explicit visual indication.

The opportunity was also taken to update the link to the Gmsh MSH definition; old URL was still valid but new one is tidier.