### PR TITLE
ensure that the points array is contiguous

### DIFF
--- a/meshio/__about__.py
+++ b/meshio/__about__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-__version__ = '1.8.9'
+__version__ = '1.8.10'
 __author__ = u'Nico Schlömer'
 __author_email__ = 'nico.schloemer@gmail.com'
 __website__ = 'https://github.com/nschloe/meshio'

--- a/meshio/gmsh_io.py
+++ b/meshio/gmsh_io.py
@@ -132,7 +132,8 @@ def read_buffer(f):
                 dtype = [('index', numpy.int32), ('x', numpy.float64, (3,))]
                 data = numpy.fromstring(f.read(num_bytes), dtype=dtype)
                 assert (data['index'] == range(1, num_nodes+1)).all()
-                points = data['x']
+                # vtk numpy support requires contiguous data
+                points = numpy.ascontiguousarray(data['x'])
                 line = f.readline().decode('utf-8')
                 assert line == '\n'
 


### PR DESCRIPTION
`numpy_to_vtk()` (used by `vtk_io`) only supports contiguous arrays.

I encountered this problem using pygmsh: a vtu file can be created by reading a binary gmsh file (as done in the examples). the error I got looks like

```
Traceback (most recent call last):
  File "rotext.py", line 94, in <module>
    meshio.write('test.vtu', *out)
  File "/home/aslash/.local/lib/python2.7/site-packages/meshio/helpers.py", line 187, in write
    field_data=field_data
  File "/home/aslash/.local/lib/python2.7/site-packages/meshio/vtk_io.py", line 236, in write
    vtk_mesh = _generate_vtk_mesh(points, cells)
  File "/home/aslash/.local/lib/python2.7/site-packages/meshio/vtk_io.py", line 335, in _generate_vtk_mesh
    vtk_array = numpy_support.numpy_to_vtk(points, deep=True)
  File "/usr/lib/python2.7/site-packages/vtk/util/numpy_support.py", line 131, in numpy_to_vtk
    assert z.flags.contiguous, 'Only contiguous arrays are supported.'
AssertionError: Only contiguous arrays are supported.
```

using vtk 7.1.1 with python2 wrappers.