### PR TITLE
Read/write nodal/cell data from MED

### DIFF
--- a/meshio/__about__.py
+++ b/meshio/__about__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-__version__ = '1.11.4'
+__version__ = '1.11.5'
 __author__ = u'Nico Schlömer'
 __author_email__ = 'nico.schloemer@gmail.com'
 __copyright__ = \

--- a/meshio/helpers.py
+++ b/meshio/helpers.py
@@ -184,7 +184,10 @@ def write(filename,
             write_binary=(file_format == 'gmsh-binary')
             )
     elif file_format == 'med':
-        med_io.write(filename, points, cells, point_data=point_data)
+        med_io.write(
+            filename, points, cells,
+            point_data=point_data,
+            cell_data=cell_data)
     elif file_format == 'medit':
         medit_io.write(filename, points, cells)
     elif file_format == 'dolfin-xml':

--- a/meshio/helpers.py
+++ b/meshio/helpers.py
@@ -182,7 +182,7 @@ def write(filename,
             write_binary=(file_format == 'gmsh-binary')
             )
     elif file_format == 'med':
-        med_io.write(filename, points, cells)
+        med_io.write(filename, points, cells, point_data=point_data)
     elif file_format == 'medit':
         medit_io.write(filename, points, cells)
     elif file_format == 'dolfin-xml':

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -5,6 +5,7 @@ I/O for MED/Salome, cf.
 <http://docs.salome-platform.org/latest/dev/MEDCoupling/med-file.html>.
 
 .. moduleauthor:: Nico Schlömer <nico.schloemer@gmail.com>
+                  Tianyi Li <tianyikillua@gmail.com>
 '''
 import numpy
 

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -77,7 +77,40 @@ def read(filename):
     if 'QU4' in mai:
         cells['quad'] = mai['QU4']['NOD'][()].reshape(4, -1).T - 1
 
-    return points, cells, {}, {}, {}
+    # Read nodal and cell data
+    cha = f['CHA']  # champs (fields) in french
+    point_data, cell_data, field_data = _read_data(cha)
+
+    return points, cells, point_data, cell_data, field_data
+
+
+def _read_data(cha):
+    point_data = {}
+    cell_data = {}
+    field_data = {}
+    for name, data in cha.items():
+        submeshes = data.keys()
+        assert len(submeshes) == 1
+        data = data[list(submeshes)[0]]
+        supp = list(data.keys())[0]
+
+        if supp == 'NOE':
+            point_data[name] = _read_nodal_data(data)
+        else:
+            pass
+
+    return point_data, cell_data, field_data
+
+
+def _read_nodal_data(data):
+    nodal_dataset = data['NOE'][data['NOE'].attrs['PFL']]
+    number = nodal_dataset.attrs['NBR']
+    values = nodal_dataset['CO'][()].reshape(-1, number).T
+    return values
+
+
+def _read_cell_data(data):
+    pass
 
 
 def write(

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -77,9 +77,12 @@ def read(filename):
     if 'QU4' in mai:
         cells['quad'] = mai['QU4']['NOD'][()].reshape(4, -1).T - 1
 
-    # Read nodal and cell data
-    cha = f['CHA']  # champs (fields) in french
-    point_data, cell_data, field_data = _read_data(cha)
+    # Read nodal and cell data if they exist
+    try:
+        cha = f['CHA']  # champs (fields) in french
+        point_data, cell_data, field_data = _read_data(cha)
+    except KeyError:
+        point_data, cell_data, field_data = {}, {}, {}
 
     return points, cells, point_data, cell_data, field_data
 

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -17,6 +17,7 @@ meshio_to_med_type = {
     'vertex': 'PO1',
     'line': 'SE2',
     }
+med_to_meshio_type = {v: k for k, v in meshio_to_med_type.items()}
 
 
 def read(filename):
@@ -68,32 +69,51 @@ def _read_data(cha):
     cell_data = {}
     field_data = {}
     for name, data in cha.items():
-        supps = ['NOE', 'MAI']
-        if all(supp not in data for supp in supps):
-            submeshes = data.keys()
-            assert len(submeshes) == 1
-            data = data[list(submeshes)[0]]
-        supp = list(data.keys())[0]
+        ts = data.keys()
+        data = data[list(ts)[-1]]  # only read the last time-step
 
-        if supp == 'NOE':  # continuous nodal data
-            point_data[name] = _read_nodal_data(data)
-        else:
-            pass
+        # MED field can contain multiple types of data
+        for supp in data:
+            if supp == 'NOE':  # continuous nodal (NOEU) data
+                point_data[name] = _read_nodal_data(data)
+            else:  # Gauss points (ELGA) or DG (ELNO) data
+                cell_data = _read_cell_data(cell_data, name, supp, data)
 
     return point_data, cell_data, field_data
 
 
 def _read_nodal_data(data):
     nodal_dataset = data['NOE'][data['NOE'].attrs['PFL']]
-    number = nodal_dataset.attrs['NBR']
-    values = nodal_dataset['CO'][()].reshape(-1, number).T
-    if values.shape[1] == 1:  # cut off for 1d arrays
+    nbr = nodal_dataset.attrs['NBR']
+    values = nodal_dataset['CO'][()].reshape(-1, nbr).T
+    if values.shape[1] == 1:  # cut off for scalars
         values = values[:, 0]
     return values
 
 
-def _read_cell_data(data):
-    pass
+def _read_cell_data(cell_data, name, supp, data):
+    med_type = supp.partition('.')[2]
+    cell_dataset = data[supp][data[supp].attrs['PFL']]
+    nbr = cell_dataset.attrs['NBR']  # number of cells
+    nga = cell_dataset.attrs['NGA']  # number of Gauss points
+
+    # Only 1 Gauss/elemental nodal point per cell
+    if nga == 1:
+        values = cell_dataset['CO'][()].reshape(-1, nbr).T
+        if values.shape[1] == 1:  # cut off for scalars
+            values = values[:, 0]
+    # Multiple Gauss/elemental nodal points per cell
+    # In general at each cell the value shape will be (nco, nga)
+    else:
+        values = cell_dataset['CO'][()].reshape(-1, nbr, nga)
+        values = numpy.swapaxes(values, 0, 1)
+
+    try:  # cell type already exists
+        key = med_to_meshio_type[med_type]
+        cell_data[key][name] = values
+    except KeyError:
+        cell_data[key] = {name: values}
+    return cell_data
 
 
 def write(
@@ -146,8 +166,8 @@ def write(
     noe_group = ts.create_group('NOE')
     noe_group.attrs.create('CGT', 1)
     noe_group.attrs.create('CGS', 1)
-    profile = 'MED_NO_PROFILE_INTERNAL'
-    noe_group.attrs.create('PFL', profile.encode('ascii'))
+    pfl = 'MED_NO_PROFILE_INTERNAL'
+    noe_group.attrs.create('PFL', pfl.encode('ascii'))
     coo = noe_group.create_dataset('COO', data=points.T.flatten())
     coo.attrs.create('CGT', 1)
     coo.attrs.create('NBR', len(points))
@@ -160,7 +180,7 @@ def write(
             mai = mai_group.create_group(med_type)
             mai.attrs.create('CGT', 1)
             mai.attrs.create('CGS', 1)
-            mai.attrs.create('PFL', profile.encode('ascii'))
+            mai.attrs.create('PFL', pfl.encode('ascii'))
             nod = mai.create_dataset('NOD', data=cells[key].T.flatten() + 1)
             nod.attrs.create('CGT', 1)
             nod.attrs.create('NBR', len(cells[key]))
@@ -171,40 +191,91 @@ def write(
     fz = fm.create_group('FAMILLE_ZERO')  # must be defined in any case
     fz.attrs.create('NUM', 0)
 
-    # Write nodal data
-    if point_data:
+    # Write nodal/cell data
+    if point_data or cell_data:
         cha = f.create_group('CHA')
+
+        # Nodal data
         for name, data in point_data.items():
-            # Field
-            field = cha.create_group(name)
-            field.attrs.create('MAI', mesh_name.encode('ascii'))
-            field.attrs.create('TYP', 6)  # MED_FLOAT64
-            field.attrs.create('UNI', b'')  # physical unit
-            field.attrs.create('UNT', b'')
-            nco = 1 if data.ndim == 1 else data.shape[1]
-            field.attrs.create('NCO', nco)  # number of components
-            field.attrs.create('NOM', _comp_nom(nco).encode('ascii'))  # component names
+            supp = 'NOEU'  # nodal data
+            _write_data(cha, mesh_name, pfl, name, supp, data)
 
-            # Time-step
-            step = '0000000000000000000100000000000000000001'
-            ts = field.create_group(step)
-            ts.attrs.create('NDT', 1)  # time step 1
-            ts.attrs.create('NOR', 1)  # iteration step 1
-            ts.attrs.create('PDT', 0.0)  # current time
-            ts.attrs.create('RDT', -1)  # NDT of the mesh
-            ts.attrs.create('ROR', -1)  # NOR of the mesh
+        # Cell data
+        # Only support writing ELEM fields with only 1 Gauss point per cell
+        # Or ELNO (DG) fields defined at every node per cell
+        for cell_type, d in cell_data.items():
+            for name, data in d.items():
 
-            # Values
-            noe = ts.create_group('NOE')
-            noe.attrs.create('GAU', b'')  # no associated Gauss points
-            noe.attrs.create('PFL', profile.encode('ascii'))
-            pfl = noe.create_group(profile)
-            pfl.attrs.create('NBR', len(data))  # number of points
-            pfl.attrs.create('NGA', 1)  # number of Gauss points (by default 1)
-            pfl.attrs.create('GAU', b'')
-            pfl.create_dataset('CO', data=data.T.flatten())
+                # Determine the nature of the cell data
+                # Either data.shape = (nbr, ) or (nbr, nco) -> ELEM
+                # or data.shape = (nbr, nco, nga) -> ELNO or ELGA
+                med_type = meshio_to_med_type[cell_type]
+                nn = int(med_type[-1])  # number of nodes per cell
+                if data.ndim <= 2:
+                    supp = 'ELEM'
+                elif data.shape[2] == nn:
+                    supp = 'ELNO'
+                else:  # general ELGA data defined at unknown Gauss points
+                    supp = 'ELGA'
+                _write_data(cha, mesh_name, pfl, name, supp, data, med_type)
 
     return
+
+
+def _write_data(cha, mesh_name, pfl, name, supp, data, med_type=None):
+    # Skip for general ELGA fields defined at unknown Gauss points
+    if supp == 'ELGA':
+        return
+
+    # Field
+    try:  # a same MED field may contain fields of different natures
+        field = cha.create_group(name)
+        field.attrs.create('MAI', mesh_name.encode('ascii'))
+        field.attrs.create('TYP', 6)  # MED_FLOAT64
+        field.attrs.create('UNI', b'')  # physical unit
+        field.attrs.create('UNT', b'')  # time unit
+        nco = 1 if data.ndim == 1 else data.shape[1]
+        field.attrs.create('NCO', nco)  # number of components
+        field.attrs.create('NOM', _comp_nom(nco).encode('ascii'))
+
+        # Time-step
+        step = '0000000000000000000100000000000000000001'
+        ts = field.create_group(step)
+        ts.attrs.create('NDT', 1)  # time step 1
+        ts.attrs.create('NOR', 1)  # iteration step 1
+        ts.attrs.create('PDT', 0.0)  # current time
+        ts.attrs.create('RDT', -1)  # NDT of the mesh
+        ts.attrs.create('ROR', -1)  # NOR of the mesh
+
+    except ValueError:  # name already exists
+        field = cha[name]
+        ts_name = list(field.keys())[-1]
+        ts = field[ts_name]
+
+    # Field information
+    if supp == 'NOEU':
+        typ = ts.create_group('NOE')
+    elif supp == 'ELNO':
+        typ = ts.create_group('NOE.' + med_type)
+    else:  # 'ELEM' with only 1 Gauss points!
+        typ = ts.create_group('MAI.' + med_type)
+
+    typ.attrs.create('GAU', b'')  # no associated Gauss points
+    typ.attrs.create('PFL', pfl.encode('ascii'))
+    pfl = typ.create_group(pfl)
+    pfl.attrs.create('NBR', len(data))  # number of points
+    if supp == 'ELNO':
+        pfl.attrs.create('NGA', data.shape[2])
+    else:
+        pfl.attrs.create('NGA', 1)
+    pfl.attrs.create('GAU', b'')
+
+    # Data
+    if supp == 'NOEU' or supp == 'ELEM':
+        pfl.create_dataset('CO', data=data.T.flatten())
+    else:  # ELNO fields
+        data = numpy.swapaxes(data, 0, 1)
+        pfl.create_dataset('CO', data=data.flatten())
 
 
 def _comp_nom(nco):

--- a/test/test_med.py
+++ b/test/test_med.py
@@ -14,6 +14,10 @@ h5py = pytest.importorskip('h5py')
     helpers.quad_mesh,
     helpers.tet_mesh,
     helpers.hex_mesh,
+    helpers.add_point_data(helpers.tri_mesh, 1),
+    helpers.add_point_data(helpers.tri_mesh, 2),
+    helpers.add_point_data(helpers.tri_mesh, 3),
+    helpers.add_point_data(helpers.hex_mesh, 3),
     ])
 def test_io(mesh):
     helpers.write_read(

--- a/test/test_med.py
+++ b/test/test_med.py
@@ -18,6 +18,9 @@ h5py = pytest.importorskip('h5py')
     helpers.add_point_data(helpers.tri_mesh, 2),
     helpers.add_point_data(helpers.tri_mesh, 3),
     helpers.add_point_data(helpers.hex_mesh, 3),
+    helpers.add_cell_data(helpers.tri_mesh, 1),
+    helpers.add_cell_data(helpers.tri_mesh, 2),
+    helpers.add_cell_data(helpers.tri_mesh, 3),
     ])
 def test_io(mesh):
     helpers.write_read(


### PR DESCRIPTION
We should now be able to read/write nodal/cell data from a MED file, see also #186.
- `NOEU`: nodal data
- `ELGA` : Gauss point data (for writing, only fields defined on exactly 1 Gauss point per cell can be written)
- `ELNO` : Gauss point data extrapolated at nodes per element (some basically the DG field)

For reading, the array of `ELGA` or `ELNO` fields has 3 dimensions `nbr`, `nco` and `nga` where `nbr` refers to the number of the concerned particular (geometric typed) cells, `nco` is the number of physical components of the field, and `nga` is the number of Gauss or elemental nodal points per cell. 

If `nga == 1`, then only one supporting point is defined per cell (the most usual case). The array will be cut off to be of shape `(nbr, nco)`. For scalar fields (`nco == 1`), it will be further cut off to be an 1-d array (convention in `meshio`). In other cases, the array is of shape `(nbr, nco, nga)`.

If `nga == nn` where `nn` is the number of nodes per cell, then we consider it to be a `ELNO` field. Otherwise it is a general `ELGA` field defined on `nga` Gauss points. Reading general `ELGA` fields is ok but writing them needs additional work, since we need to write Gauss point information (location, weights) into the MED file. It can be done in the future.
