### PR TITLE
add check for filename and file_format during read and write

### DIFF
--- a/meshio/helpers.py
+++ b/meshio/helpers.py
@@ -83,6 +83,7 @@ def check_filename(filename, file_format=None):
     # Checks the input and output file name and format.
     # https://stackoverflow.com/q/4843173/353337
     assert isinstance(filename, str), 'Filename is not a string.: {}'.format(filename)
+    assert isinstance(filename, str), 'Invalid input \'{}\''.format(filename)
 
     if not file_format:
         # deduce file format from extension

--- a/meshio/helpers.py
+++ b/meshio/helpers.py
@@ -82,7 +82,6 @@ _extension_to_filetype = {
 def check_filename(filename, file_format=None):
     # Checks the input and output file name and format.
     # https://stackoverflow.com/q/4843173/353337
-    assert isinstance(filename, str), 'Filename is not a string.: {}'.format(filename)
     assert isinstance(filename, str), 'Invalid input \'{}\''.format(filename)
 
     if not file_format:

--- a/meshio/helpers.py
+++ b/meshio/helpers.py
@@ -82,17 +82,16 @@ _extension_to_filetype = {
 def check_filename(filename, file_format=None):
     # Checks the input and output file name and format.
     # https://stackoverflow.com/q/4843173/353337
-    assert isinstance(filename, str), 'No such file or directory: {}'.format(filename)
+    assert isinstance(filename, str), 'Filename is not a string.: {}'.format(filename)
 
     if not file_format:
         # deduce file format from extension
         extension = '.' + os.path.basename(filename).split(os.extsep, 1)[-1]
         # check whether the file format is supported
-        if extension in _extension_to_filetype:
-            file_format = _extension_to_filetype[extension]
-        else:
-            assert False, ('Unknown file extension \'{}\' of \'{}\'.'
-                           .format(extension, filename))
+        assert extension in _extension_to_filetype, ('Unknown file extension \'{}\' of \'{}\'.'
+                                                     .format(extension, filename))
+        file_format = _extension_to_filetype[extension]
+
     return filename, file_format
 
 
@@ -140,9 +139,8 @@ def read(filename, file_format=None):
         'exodus': exodus_io,
     }
     # check whether the user specified format is supported
-    if file_format not in format_to_reader:
-        assert False, ('Unknown file format \'{}\' of \'{}\'.'
-                       .format(file_format, filename))
+    assert file_format in format_to_reader, ('Unknown file format \'{}\' of \'{}\'.'
+                                             .format(file_format, filename))
     return format_to_reader[file_format].read(filename)
 
 


### PR DESCRIPTION
The filename check was made only in read and not write. Also, no check was made to see whether the user-specified file format is supported by the code. This lead to 'KeyError' on the prompt which is not very descriptive for the end user. Also, there was code repetition in 'read' and 'write' modules. I have added a new function 'check_filename' that would check whether the specified file format is supported by the code. This is in regards to Issue #208. 