### PR TITLE
[xdmf] Fixed serialization bug for mixed data with lines

### DIFF
--- a/meshio/xdmf_io.py
+++ b/meshio/xdmf_io.py
@@ -492,11 +492,13 @@ class XdmfWriter(object):
                 )
             total_num_cell_items = \
                 sum(numpy.prod(c.shape) for c in cells.values())
-            dim = str(total_num_cell_items + total_num_cells)
+            dim = total_num_cell_items + total_num_cells
             # Lines translate to Polylines, and one needs to specify the exact
             # number of nodes. Hence, prepend 2.
             if 'line' in cells:
                 cells['line'] = numpy.insert(cells['line'], 0, 2, axis=1)
+                dim += len(cells['line'])
+            dim = str(dim)
             cd = numpy.concatenate([
                 # prepend column with xdmf type index
                 numpy.insert(


### PR DESCRIPTION
This patch fixes a bug in the generation of xdmf data file.
It appears when one wants to open the result file in ParaView

Below is a python code that reproduce the bug: it creates xdmf file that makes ParaView crash. With this patch, the test code generate xdmf file that can be opened in ParaView.

    
    import numpy as np
    import meshio

    points = np.array([
        [0.0, 0.0, 0.0],
        [0.0, 1.0, 0.0],
        [0.0, 0.0, 1.0],
        ])
    cells = {
        'line':np.array([
            [0, 1],
            [1, 2],
            [2, 0],
            ]),
        'triangle': np.array([
            [0, 1, 2]
            ])
        }
    meshio.write(
        'foo.xdmf',
        points,
        cells
    )