### PR TITLE
Gmsh: Support for periodicity

### DIFF
--- a/meshio/mesh.py
+++ b/meshio/mesh.py
@@ -12,6 +12,7 @@ class Mesh(object):
         cell_data=None,
         field_data=None,
         node_sets=None,
+        gmsh_periodic=None,
     ):
         self.points = points
         self.cells = cells
@@ -19,6 +20,7 @@ class Mesh(object):
         self.cell_data = cell_data if cell_data else {}
         self.field_data = field_data if field_data else {}
         self.node_sets = node_sets if node_sets else {}
+        self.gmsh_periodic = gmsh_periodic
         return
 
     def __repr__(self):

--- a/test/test_gmsh.py
+++ b/test/test_gmsh.py
@@ -1,10 +1,22 @@
 # -*- coding: utf-8 -*-
 #
+import copy
 import pytest
 
 import meshio
 
 import helpers
+
+
+def gmsh_periodic():
+    mesh = copy.deepcopy(helpers.quad_mesh)
+    trns = "Affine{}".format(" 0" * 16)  # just for io testing
+    mesh.gmsh_periodic = [
+        [0, (3, 1), None, [[2, 0]]],
+        [0, (4, 6), None, [[3, 5]]],
+        [1, (2, 1), trns, [[5, 0], [4, 1], [4, 2]]],
+    ]
+    return mesh
 
 
 @pytest.mark.parametrize(
@@ -28,6 +40,7 @@ import helpers
         helpers.add_field_data(helpers.tri_mesh, [1, 2], int),
         helpers.add_field_data(helpers.tet_mesh, [1, 3], int),
         helpers.add_field_data(helpers.hex_mesh, [1, 3], int),
+        gmsh_periodic(),
     ],
 )
 @pytest.mark.parametrize("write_binary", [False, True])


### PR DESCRIPTION
This PR adds support for reading/writing `$Periodic` sections in Gmsh files. Note however than I'm stashing the periodic information in the field data entry named `gmsh:periodic`. I don't really like it, but I think we do not have a better mechanism yet to pass this stuff around.