### PR TITLE
Implementation ABAQUS inp format input/output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,109 +1,1 @@
-# meshio
-
-[![CircleCI](https://img.shields.io/circleci/project/github/nschloe/meshio/master.svg)](https://circleci.com/gh/nschloe/meshio)
-[![codecov](https://img.shields.io/codecov/c/github/nschloe/meshio.svg)](https://codecov.io/gh/nschloe/meshio)
-[![Codacy grade](https://img.shields.io/codacy/grade/dc23fe7f7d4540b0a405110b3ae97dc6.svg)](https://app.codacy.com/app/nschloe/meshio/dashboard)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
-[![PyPi Version](https://img.shields.io/pypi/v/meshio.svg)](https://pypi.org/project/meshio)
-[![Debian CI](https://badges.debian.net/badges/debian/testing/python3-meshio/version.svg)](https://tracker.debian.org/pkg/python-meshio:q)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1173115.svg)](https://doi.org/10.5281/zenodo.1173115)
-[![GitHub stars](https://img.shields.io/github/stars/nschloe/meshio.svg?logo=github&label=Stars)](https://github.com/nschloe/meshio)
-
-<p align="center">
-  <img src="https://nschloe.github.io/meshio/meshio_logo.png" width="20%">
-</p>
-
-There are various mesh formats available for representing unstructured meshes,
-e.g.,
-
- * [ANSYS msh](http://www.afs.enea.it/fluent/Public/Fluent-Doc/PDF/chp03.pdf)
- * [DOLFIN XML](http://manpages.ubuntu.com/manpages/wily/man1/dolfin-convert.1.html)
- * [Exodus](https://cubit.sandia.gov/public/13.2/help_manual/WebHelp/finite_element_model/exodus/block_specification.htm)
- * [H5M](https://www.mcs.anl.gov/~fathom/moab-docs/h5mmain.html)
- * [Medit](https://people.sc.fsu.edu/~jburkardt/data/medit/medit.html)
- * [MED/Salome](http://docs.salome-platform.org/latest/dev/MEDCoupling/med-file.html)
- * [Gmsh](http://gmsh.info/doc/texinfo/gmsh.html#File-formats)
- * [OFF](http://segeval.cs.princeton.edu/public/off_format.html)
- * [PERMAS](http://www.intes.de)
- * [STL](https://en.wikipedia.org/wiki/STL_(file_format))
- * [VTK](https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf)
- * [VTU](https://www.vtk.org/Wiki/VTK_XML_Formats)
- * [XDMF](http://www.xdmf.org/index.php/XDMF_Model_and_Format)
- * [ABAQUS inp] (http://abaqus.software.polimi.it/v6.14/books/key/default.htm)
-
-meshio can read and write all of these formats and smoothly converts between
-them. Simply call
-```
-meshio-convert input.msh output.vtu
-```
-with any of the supported formats.
-
-In Python, simply call
-```python
-points, cells, point_data, cell_data, field_data = \
-    meshio.read(args.infile)
-```
-to read a mesh. To write, do
-```python
-points = numpy.array([
-    [0.0, 0.0, 0.0],
-    [0.0, 1.0, 0.0],
-    [0.0, 0.0, 1.0],
-    ])
-cells = {
-    'triangle': numpy.array([
-        [0, 1, 2]
-        ])
-    }
-meshio.write(
-    'foo.vtk',
-    points,
-    cells,
-    # Optionally provide extra data on points, cells, etc.
-    # point_data=point_data,
-    # cell_data=cell_data,
-    # field_data=field_data
-    )
-```
-For both input and output, you can optionally specify the exact `file_format`
-(in case you would like to enforce binary over ASCII VTK, for example).
-
-### Installation
-
-meshio is [available from the Python Package
-Index](https://pypi.org/project/meshio/), so simply type
-```
-pip install -U meshio
-```
-to install or upgrade.
-
-### Usage
-
-Just
-```
-import meshio
-```
-and make use of all the goodies the module provides.
-
-
-### Testing
-
-To run the meshio unit tests, check out this repository and type
-```
-pytest
-```
-
-### Distribution
-
-To create a new release
-
-1. bump the `__version__` number,
-
-2. tag and upload to PyPi:
-    ```
-    make publish
-    ```
-
-### License
-
-meshio is published under the [MIT license](https://en.wikipedia.org/wiki/MIT_License).
+# meshio[![CircleCI](https://img.shields.io/circleci/project/github/nschloe/meshio/master.svg)](https://circleci.com/gh/nschloe/meshio)[![codecov](https://img.shields.io/codecov/c/github/nschloe/meshio.svg)](https://codecov.io/gh/nschloe/meshio)[![Codacy grade](https://img.shields.io/codacy/grade/dc23fe7f7d4540b0a405110b3ae97dc6.svg)](https://app.codacy.com/app/nschloe/meshio/dashboard)[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)[![PyPi Version](https://img.shields.io/pypi/v/meshio.svg)](https://pypi.org/project/meshio)[![Debian CI](https://badges.debian.net/badges/debian/testing/python3-meshio/version.svg)](https://tracker.debian.org/pkg/python-meshio:q)[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1173115.svg)](https://doi.org/10.5281/zenodo.1173115)[![GitHub stars](https://img.shields.io/github/stars/nschloe/meshio.svg?logo=github&label=Stars)](https://github.com/nschloe/meshio)<p align="center">  <img src="https://nschloe.github.io/meshio/meshio_logo.png" width="20%"></p>There are various mesh formats available for representing unstructured meshes,e.g., * [ANSYS msh](http://www.afs.enea.it/fluent/Public/Fluent-Doc/PDF/chp03.pdf) * [DOLFIN XML](http://manpages.ubuntu.com/manpages/wily/man1/dolfin-convert.1.html) * [Exodus](https://cubit.sandia.gov/public/13.2/help_manual/WebHelp/finite_element_model/exodus/block_specification.htm) * [H5M](https://www.mcs.anl.gov/~fathom/moab-docs/h5mmain.html) * [Medit](https://people.sc.fsu.edu/~jburkardt/data/medit/medit.html) * [MED/Salome](http://docs.salome-platform.org/latest/dev/MEDCoupling/med-file.html) * [Gmsh](http://gmsh.info/doc/texinfo/gmsh.html#File-formats) * [OFF](http://segeval.cs.princeton.edu/public/off_format.html) * [PERMAS](http://www.intes.de) * [STL](https://en.wikipedia.org/wiki/STL_(file_format)) * [VTK](https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf) * [VTU](https://www.vtk.org/Wiki/VTK_XML_Formats) * [XDMF](http://www.xdmf.org/index.php/XDMF_Model_and_Format) * [ABAQUS inp](http://abaqus.software.polimi.it/v6.14/books/key/default.htm)meshio can read and write all of these formats and smoothly converts betweenthem. Simply call```meshio-convert input.msh output.vtu```with any of the supported formats.In Python, simply call```pythonpoints, cells, point_data, cell_data, field_data = \    meshio.read(args.infile)```to read a mesh. To write, do```pythonpoints = numpy.array([    [0.0, 0.0, 0.0],    [0.0, 1.0, 0.0],    [0.0, 0.0, 1.0],    ])cells = {    'triangle': numpy.array([        [0, 1, 2]        ])    }meshio.write(    'foo.vtk',    points,    cells,    # Optionally provide extra data on points, cells, etc.    # point_data=point_data,    # cell_data=cell_data,    # field_data=field_data    )```For both input and output, you can optionally specify the exact `file_format`(in case you would like to enforce binary over ASCII VTK, for example).### Installationmeshio is [available from the Python PackageIndex](https://pypi.org/project/meshio/), so simply type```pip install -U meshio```to install or upgrade.### UsageJust```import meshio```and make use of all the goodies the module provides.### TestingTo run the meshio unit tests, check out this repository and type```pytest```### DistributionTo create a new release1. bump the `__version__` number,2. tag and upload to PyPi:    ```    make publish    ```### Licensemeshio is published under the [MIT license](https://en.wikipedia.org/wiki/MIT_License).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 There are various mesh formats available for representing unstructured meshes,
 e.g.,
 
+ * [ABAQUS inp](http://http://abaqus.software.polimi.it/v6.14/index.html)
  * [ANSYS msh](http://www.afs.enea.it/fluent/Public/Fluent-Doc/PDF/chp03.pdf)
  * [DOLFIN XML](http://manpages.ubuntu.com/manpages/wily/man1/dolfin-convert.1.html)
  * [Exodus](https://cubit.sandia.gov/public/13.2/help_manual/WebHelp/finite_element_model/exodus/block_specification.htm)
@@ -29,7 +30,6 @@ e.g.,
  * [VTK](https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf)
  * [VTU](https://www.vtk.org/Wiki/VTK_XML_Formats)
  * [XDMF](http://www.xdmf.org/index.php/XDMF_Model_and_Format)
- * [ABAQUS inp](http://abaqus.software.polimi.it/v6.14/index.html)
 
 meshio can read and write all of these formats and smoothly converts between
 them. Simply call
@@ -107,4 +107,3 @@ To create a new release
 ### License
 
 meshio is published under the [MIT license](https://en.wikipedia.org/wiki/MIT_License).
-

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ e.g.,
  * [VTK](https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf)
  * [VTU](https://www.vtk.org/Wiki/VTK_XML_Formats)
  * [XDMF](http://www.xdmf.org/index.php/XDMF_Model_and_Format)
+ * [ABAQUS inp] (http://abaqus.software.polimi.it/v6.14/books/key/default.htm)
 
 meshio can read and write all of these formats and smoothly converts between
 them. Simply call

--- a/README.md
+++ b/README.md
@@ -1,1 +1,110 @@
-# meshio[![CircleCI](https://img.shields.io/circleci/project/github/nschloe/meshio/master.svg)](https://circleci.com/gh/nschloe/meshio)[![codecov](https://img.shields.io/codecov/c/github/nschloe/meshio.svg)](https://codecov.io/gh/nschloe/meshio)[![Codacy grade](https://img.shields.io/codacy/grade/dc23fe7f7d4540b0a405110b3ae97dc6.svg)](https://app.codacy.com/app/nschloe/meshio/dashboard)[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)[![PyPi Version](https://img.shields.io/pypi/v/meshio.svg)](https://pypi.org/project/meshio)[![Debian CI](https://badges.debian.net/badges/debian/testing/python3-meshio/version.svg)](https://tracker.debian.org/pkg/python-meshio:q)[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1173115.svg)](https://doi.org/10.5281/zenodo.1173115)[![GitHub stars](https://img.shields.io/github/stars/nschloe/meshio.svg?logo=github&label=Stars)](https://github.com/nschloe/meshio)<p align="center">  <img src="https://nschloe.github.io/meshio/meshio_logo.png" width="20%"></p>There are various mesh formats available for representing unstructured meshes,e.g., * [ANSYS msh](http://www.afs.enea.it/fluent/Public/Fluent-Doc/PDF/chp03.pdf) * [DOLFIN XML](http://manpages.ubuntu.com/manpages/wily/man1/dolfin-convert.1.html) * [Exodus](https://cubit.sandia.gov/public/13.2/help_manual/WebHelp/finite_element_model/exodus/block_specification.htm) * [H5M](https://www.mcs.anl.gov/~fathom/moab-docs/h5mmain.html) * [Medit](https://people.sc.fsu.edu/~jburkardt/data/medit/medit.html) * [MED/Salome](http://docs.salome-platform.org/latest/dev/MEDCoupling/med-file.html) * [Gmsh](http://gmsh.info/doc/texinfo/gmsh.html#File-formats) * [OFF](http://segeval.cs.princeton.edu/public/off_format.html) * [PERMAS](http://www.intes.de) * [STL](https://en.wikipedia.org/wiki/STL_(file_format)) * [VTK](https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf) * [VTU](https://www.vtk.org/Wiki/VTK_XML_Formats) * [XDMF](http://www.xdmf.org/index.php/XDMF_Model_and_Format) * [ABAQUS inp](http://abaqus.software.polimi.it/v6.14/books/key/default.htm)meshio can read and write all of these formats and smoothly converts betweenthem. Simply call```meshio-convert input.msh output.vtu```with any of the supported formats.In Python, simply call```pythonpoints, cells, point_data, cell_data, field_data = \    meshio.read(args.infile)```to read a mesh. To write, do```pythonpoints = numpy.array([    [0.0, 0.0, 0.0],    [0.0, 1.0, 0.0],    [0.0, 0.0, 1.0],    ])cells = {    'triangle': numpy.array([        [0, 1, 2]        ])    }meshio.write(    'foo.vtk',    points,    cells,    # Optionally provide extra data on points, cells, etc.    # point_data=point_data,    # cell_data=cell_data,    # field_data=field_data    )```For both input and output, you can optionally specify the exact `file_format`(in case you would like to enforce binary over ASCII VTK, for example).### Installationmeshio is [available from the Python PackageIndex](https://pypi.org/project/meshio/), so simply type```pip install -U meshio```to install or upgrade.### UsageJust```import meshio```and make use of all the goodies the module provides.### TestingTo run the meshio unit tests, check out this repository and type```pytest```### DistributionTo create a new release1. bump the `__version__` number,2. tag and upload to PyPi:    ```    make publish    ```### Licensemeshio is published under the [MIT license](https://en.wikipedia.org/wiki/MIT_License).
+# meshio
+
+[![CircleCI](https://img.shields.io/circleci/project/github/nschloe/meshio/master.svg)](https://circleci.com/gh/nschloe/meshio)
+[![codecov](https://img.shields.io/codecov/c/github/nschloe/meshio.svg)](https://codecov.io/gh/nschloe/meshio)
+[![Codacy grade](https://img.shields.io/codacy/grade/dc23fe7f7d4540b0a405110b3ae97dc6.svg)](https://app.codacy.com/app/nschloe/meshio/dashboard)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+[![PyPi Version](https://img.shields.io/pypi/v/meshio.svg)](https://pypi.org/project/meshio)
+[![Debian CI](https://badges.debian.net/badges/debian/testing/python3-meshio/version.svg)](https://tracker.debian.org/pkg/python-meshio:q)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1173115.svg)](https://doi.org/10.5281/zenodo.1173115)
+[![GitHub stars](https://img.shields.io/github/stars/nschloe/meshio.svg?logo=github&label=Stars)](https://github.com/nschloe/meshio)
+
+<p align="center">
+  <img src="https://nschloe.github.io/meshio/meshio_logo.png" width="20%">
+</p>
+
+There are various mesh formats available for representing unstructured meshes,
+e.g.,
+
+ * [ANSYS msh](http://www.afs.enea.it/fluent/Public/Fluent-Doc/PDF/chp03.pdf)
+ * [DOLFIN XML](http://manpages.ubuntu.com/manpages/wily/man1/dolfin-convert.1.html)
+ * [Exodus](https://cubit.sandia.gov/public/13.2/help_manual/WebHelp/finite_element_model/exodus/block_specification.htm)
+ * [H5M](https://www.mcs.anl.gov/~fathom/moab-docs/h5mmain.html)
+ * [Medit](https://people.sc.fsu.edu/~jburkardt/data/medit/medit.html)
+ * [MED/Salome](http://docs.salome-platform.org/latest/dev/MEDCoupling/med-file.html)
+ * [Gmsh](http://gmsh.info/doc/texinfo/gmsh.html#File-formats)
+ * [OFF](http://segeval.cs.princeton.edu/public/off_format.html)
+ * [PERMAS](http://www.intes.de)
+ * [STL](https://en.wikipedia.org/wiki/STL_(file_format))
+ * [VTK](https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf)
+ * [VTU](https://www.vtk.org/Wiki/VTK_XML_Formats)
+ * [XDMF](http://www.xdmf.org/index.php/XDMF_Model_and_Format)
+ * [ABAQUS inp](http://abaqus.software.polimi.it/v6.14/index.html)
+
+meshio can read and write all of these formats and smoothly converts between
+them. Simply call
+```
+meshio-convert input.msh output.vtu
+```
+with any of the supported formats.
+
+In Python, simply call
+```python
+points, cells, point_data, cell_data, field_data = \
+    meshio.read(args.infile)
+```
+to read a mesh. To write, do
+```python
+points = numpy.array([
+    [0.0, 0.0, 0.0],
+    [0.0, 1.0, 0.0],
+    [0.0, 0.0, 1.0],
+    ])
+cells = {
+    'triangle': numpy.array([
+        [0, 1, 2]
+        ])
+    }
+meshio.write(
+    'foo.vtk',
+    points,
+    cells,
+    # Optionally provide extra data on points, cells, etc.
+    # point_data=point_data,
+    # cell_data=cell_data,
+    # field_data=field_data
+    )
+```
+For both input and output, you can optionally specify the exact `file_format`
+(in case you would like to enforce binary over ASCII VTK, for example).
+
+### Installation
+
+meshio is [available from the Python Package
+Index](https://pypi.org/project/meshio/), so simply type
+```
+pip install -U meshio
+```
+to install or upgrade.
+
+### Usage
+
+Just
+```
+import meshio
+```
+and make use of all the goodies the module provides.
+
+
+### Testing
+
+To run the meshio unit tests, check out this repository and type
+```
+pytest
+```
+
+### Distribution
+
+To create a new release
+
+1. bump the `__version__` number,
+
+2. tag and upload to PyPi:
+    ```
+    make publish
+    ```
+
+### License
+
+meshio is published under the [MIT license](https://en.wikipedia.org/wiki/MIT_License).
+

--- a/meshio/abaqus_io.py
+++ b/meshio/abaqus_io.py
@@ -237,7 +237,7 @@ def read_set(f, params_map):
         if line.startswith("*"):
             break;
         set_ids += line.strip(', ').split(',')
-        
+
     if 'generate' in params_map:
         assert len(set_ids) == 3, set_ids
         set_ids = numpy.arange(int(set_ids[0]), int(set_ids[1]), int(set_ids[2]))

--- a/meshio/abaqus_io.py
+++ b/meshio/abaqus_io.py
@@ -41,17 +41,17 @@ abaqus_to_meshio_type = {
     "S8R": "quad8",
     "S8R5": "quad8",
     "S9R5": "quad9",
-   # "QUAD": "quad",
-   # "QUAD4": "quad",
-   # "QUAD5": "quad5",
-   # "QUAD8": "quad8",
-   # "QUAD9": "quad9",
+    # "QUAD": "quad",
+    # "QUAD4": "quad",
+    # "QUAD5": "quad5",
+    # "QUAD8": "quad8",
+    # "QUAD9": "quad9",
     #
     "STRI3": "triangle",
     "S3": "triangle",
     "S3R": "triangle",
     "S3RS": "triangle",
-    #"TRI7": "triangle7",
+    # "TRI7": "triangle7",
     # 'TRISHELL': 'triangle',
     # 'TRISHELL3': 'triangle',
     # 'TRISHELL7': 'triangle',
@@ -65,27 +65,28 @@ abaqus_to_meshio_type = {
     "C3D8IH": "hexahedron",
     "C3D8R": "hexahedron",
     "C3D8RH": "hexahedron",
-    #"HEX9": "hexahedron9",
+    # "HEX9": "hexahedron9",
     "C3D20": "hexahedron20",
     "C3D20H": "hexahedron20",
     "C3D20R": "hexahedron20",
     "C3D20RH": "hexahedron20",
-    #"HEX27": "hexahedron27",
+    # "HEX27": "hexahedron27",
     #
     "C3D4": "tetra",
     "C3D4H": "tetra4",
-    #"TETRA8": "tetra8",
+    # "TETRA8": "tetra8",
     "C3D10": "tetra10",
     "C3D10H": "tetra10",
     "C3D10I": "tetra10",
     "C3D10M": "tetra10",
     "C3D10MH": "tetra10",
-    #"TETRA14": "tetra14",
+    # "TETRA14": "tetra14",
     #
-    #"PYRAMID": "pyramid",
+    # "PYRAMID": "pyramid",
     "C3D6": "wedge",
 }
 meshio_to_abaqus_type = {v: k for k, v in abaqus_to_meshio_type.items()}
+
 
 def read(filename):
     """Reads a Abaqus inp file.
@@ -93,6 +94,7 @@ def read(filename):
     with open(filename, "r") as f:
         out = read_buffer(f)
     return out
+
 
 def read_buffer(f):
     # Initialize the optional data fields
@@ -103,7 +105,7 @@ def read_buffer(f):
     field_data = {}
     cell_data = {}
     point_data = {}
-    point_gid = numpy.array([], dtype=int )
+    point_gid = numpy.array([], dtype=int)
 
     while True:
         line = f.readline()
@@ -112,54 +114,56 @@ def read_buffer(f):
             break
 
         if line.startswith("*"):
-            word = line.strip('*').upper()
-            if word == 'HEADING':
+            word = line.strip("*").upper()
+            if word == "HEADING":
                 pass
-            elif word.startswith('PREPRINT'):
+            elif word.startswith("PREPRINT"):
                 pass
-            elif word.startswith('NODE'):
+            elif word.startswith("NODE"):
                 points, point_gid = _read_nodes(f, point_gid, points)
-            elif word.startswith('ELEMENT'):
-                cells = _read_cells( f, word, cells )
-            elif word.startswith('NSET'):
-                params_map = get_param_map(word, required_keys=['NSET'])
+            elif word.startswith("ELEMENT"):
+                cells = _read_cells(f, word, cells)
+            elif word.startswith("NSET"):
+                params_map = get_param_map(word, required_keys=["NSET"])
                 setids = read_set(f, params_map)
-                name = params_map['NSET']
+                name = params_map["NSET"]
                 if name not in nsets:
                     nsets[name] = []
                 nsets[name].append(setids)
-            elif word.startswith('ELSET'):
-                params_map = get_param_map(word, required_keys=['ELSET'])
+            elif word.startswith("ELSET"):
+                params_map = get_param_map(word, required_keys=["ELSET"])
                 setids = read_set(f, params_map)
-                name = params_map['ELSET']
+                name = params_map["ELSET"]
                 if name not in elsets:
                     elsets[name] = []
                 elsets[name].append(setids)
             else:
                 pass
 
-    points = numpy.reshape(points, (-1,3))
+    points = numpy.reshape(points, (-1, 3))
     cells = _scan_cells(point_gid, cells)
     return points, cells, point_data, cell_data, field_data
+
 
 def _read_nodes(f, point_gid, points):
     while True:
         last_pos = f.tell()
         line = f.readline()
         if line.startswith("*"):
-            break;
-        data = [float(k) for k in filter(None, line.strip().split(','))]
-        point_gid = numpy.append( point_gid, int(data[0]) )
-        points = numpy.append(points,data[-3:])
+            break
+        data = [float(k) for k in filter(None, line.strip().split(","))]
+        point_gid = numpy.append(point_gid, int(data[0]))
+        points = numpy.append(points, data[-3:])
 
     f.seek(last_pos)
     return points, point_gid
 
+
 def _read_cells(f, line0, cells):
-    sline = line0.split(',')[1:]
+    sline = line0.split(",")[1:]
     etype_sline = sline[0]
-    assert 'TYPE' in etype_sline, etype_sline
-    etype = etype_sline.split('=')[1].strip()
+    assert "TYPE" in etype_sline, etype_sline
+    etype = etype_sline.split("=")[1].strip()
     if etype not in abaqus_to_meshio_type:
         msg = "Element type not available: " + etype
         raise RuntimeError(msg)
@@ -171,8 +175,8 @@ def _read_cells(f, line0, cells):
         last_pos = f.tell()
         line = f.readline()
         if line.startswith("*"):
-            break;
-        data = [int(k) for k in filter(None, line.split(','))]
+            break
+        data = [int(k) for k in filter(None, line.split(","))]
         cells[t].append(data[-num_nodes_per_elem:])
 
     # convert to numpy arrays
@@ -184,11 +188,13 @@ def _read_cells(f, line0, cells):
     f.seek(last_pos)
     return cells
 
+
 def _scan_cells(point_gid, cells):
     for arr in cells.values():
-        for value in numpy.nditer(arr,op_flags=['readwrite'] ):
+        for value in numpy.nditer(arr, op_flags=["readwrite"]):
             value[...] = numpy.flatnonzero(point_gid == value)[0]
     return cells
+
 
 def get_param_map(word, required_keys=None):
     """
@@ -207,76 +213,68 @@ def get_param_map(word, required_keys=None):
     """
     if required_keys is None:
         required_keys = []
-    words = word.split(',')
+    words = word.split(",")
     param_map = {}
     for wordi in words:
-        if '=' not in wordi:
+        if "=" not in wordi:
             key = wordi.strip()
             value = None
         else:
-            sword = wordi.split('=')
+            sword = wordi.split("=")
             assert len(sword) == 2, sword
             key = sword[0].strip()
             value = sword[1].strip()
         param_map[key] = value
 
-    msg = ''
+    msg = ""
     for key in required_keys:
         if key not in param_map:
-            msg += '%r not found in %r\n' % (key, word)
+            msg += "%r not found in %r\n" % (key, word)
     if msg:
         raise RuntimeError(msg)
     return param_map
 
+
 def read_set(f, params_map):
     """reads a set"""
-    set_ids=[]
+    set_ids = []
     while True:
         last_pos = f.tell()
         line = f.readline()
         if line.startswith("*"):
-            break;
-        set_ids += line.strip(', ').split(',')
+            break
+        set_ids += line.strip(", ").split(",")
 
-    if 'generate' in params_map:
+    if "generate" in params_map:
         assert len(set_ids) == 3, set_ids
         set_ids = numpy.arange(int(set_ids[0]), int(set_ids[1]), int(set_ids[2]))
     else:
         try:
-            set_ids = numpy.unique(numpy.array(set_ids, dtype='int32'))
+            set_ids = numpy.unique(numpy.array(set_ids, dtype="int32"))
         except ValueError:
             print(set_ids)
             raise
     f.seek(last_pos)
     return set_ids
 
-def write(
-    filename,
-    points,
-    cells,
-    point_data=None,
-    cell_data=None,
-    field_data=None,
-    write_binary=True,
-):
+
+def write(filename, points, cells, point_data=None, cell_data=None, field_data=None):
     point_data = {} if point_data is None else point_data
     cell_data = {} if cell_data is None else cell_data
     field_data = {} if field_data is None else field_data
-    
+
     with open(filename, "wt") as f:
-        f.write('*Heading\n')
+        f.write("*Heading\n")
         f.write(" Abaqus DataFile Version 6.14\n")
         f.write("written by meshio v{}\n".format(__version__))
-        f.write('*Node\n')
+        f.write("*Node\n")
         for k, x in enumerate(points):
-            f.write(
-                "{}, {!r}, {!r}, {!r}\n".format(k + 1, x[0], x[1], x[2])
-            )
+            f.write("{}, {!r}, {!r}, {!r}\n".format(k + 1, x[0], x[1], x[2]))
         eid = 0
         for cell_type, node_idcs in cells.items():
-            f.write('*Element,type='+ meshio_to_abaqus_type[cell_type]+'\n')
+            f.write("*Element,type=" + meshio_to_abaqus_type[cell_type] + "\n")
             for row in node_idcs:
-                eid+=1
-                nids_strs = (str(nid+1) for nid in row.tolist())
-                f.write(str(eid) + ',' + ','.join(nids_strs) + '\n')
-        f.write('*end')
+                eid += 1
+                nids_strs = (str(nid + 1) for nid in row.tolist())
+                f.write(str(eid) + "," + ",".join(nids_strs) + "\n")
+        f.write("*end")

--- a/meshio/abaqus_io.py
+++ b/meshio/abaqus_io.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+#
+"""
+I/O for Abaqus inp files.
+
+.. moduleauthor:: Xi YUAN <hill_yuan@hotmail.com>
+"""
+import numpy
+
+from .__about__ import __version__
+from .gmsh_io import num_nodes_per_cell
+
+
+abaqus_to_meshio_type = {
+    # trusss
+    "T2D2": "line",
+    "T2D2H": "line",
+    "T2D3": "line3",
+    "T2D3H": "line3",
+    "T3D2": "line",
+    "T3D2H": "line",
+    "T3D3": "line3",
+    "T3D3H": "line3",
+    # beams
+    "B21": "line",
+    "B21H": "line",
+    "B22": "line3",
+    "B22H": "line3",
+    "B31": "line",
+    "B31H": "line",
+    "B32": "line3",
+    "B32H": "line3",
+    "B33": "line3",
+    "B33H": "line3",
+    # surfaces
+    "S4": "quad",
+    "S4R": "quad",
+    "S4RS": "quad",
+    "S4RSW": "quad",
+    "S4R5": "quad",
+    "S8R": "quad8",
+    "S8R5": "quad8",
+    "S9R5": "quad9",
+   # "QUAD": "quad",
+   # "QUAD4": "quad",
+   # "QUAD5": "quad5",
+   # "QUAD8": "quad8",
+   # "QUAD9": "quad9",
+    #
+    "STRI3": "triangle",
+    "S3": "triangle",
+    "S3R": "triangle",
+    "S3RS": "triangle",
+    #"TRI7": "triangle7",
+    # 'TRISHELL': 'triangle',
+    # 'TRISHELL3': 'triangle',
+    # 'TRISHELL7': 'triangle',
+    #
+    "STRI65": "triangle6",
+    # 'TRISHELL6': 'triangle6',
+    # volumes
+    "C3D8": "hexahedron",
+    "C3D8H": "hexahedron",
+    "C3D8I": "hexahedron",
+    "C3D8IH": "hexahedron",
+    "C3D8R": "hexahedron",
+    "C3D8RH": "hexahedron",
+    #"HEX9": "hexahedron9",
+    "C3D20": "hexahedron20",
+    "C3D20H": "hexahedron20",
+    "C3D20R": "hexahedron20",
+    "C3D20RH": "hexahedron20",
+    #"HEX27": "hexahedron27",
+    #
+    "C3D4": "tetra",
+    "C3D4H": "tetra4",
+    #"TETRA8": "tetra8",
+    "C3D10": "tetra10",
+    "C3D10H": "tetra10",
+    "C3D10I": "tetra10",
+    "C3D10M": "tetra10",
+    "C3D10MH": "tetra10",
+    #"TETRA14": "tetra14",
+    #
+    #"PYRAMID": "pyramid",
+    "C3D6": "wedge",
+}
+meshio_to_abaqus_type = {v: k for k, v in abaqus_to_meshio_type.items()}
+
+def read(filename):
+    """Reads a Abaqus inp file.
+    """
+    with open(filename, "r") as f:
+        out = read_buffer(f)
+    return out
+
+def read_buffer(f):
+    # Initialize the optional data fields
+    points = []
+    cells = {}
+    nsets = {}
+    elsets = {}
+
+    while True:
+        line = f.readline().decode("utf-8")
+        if not line:
+            # EOF
+            break
+
+        if line.startswith("*"):
+            word = line.strip('*').upper()
+            if word == 'HEADING':
+                pass
+            elif word.startswith('PREPRINT'):
+                pass
+            elif word.startswith('NODE'):
+                points = _read_nodes(f, points)
+            elif word.startswith('ELEMENT'):
+                cells = _read_cells( f, word, cells )
+            elif word.startswith('NSET'):
+                params_map = get_param_map(word, required_keys=['NSET'])
+                setids = read_set(f, params_map)
+                name = params_map['NSET']
+                if name not in nsets:
+                    nsets[name] = []
+                nsets[name].append(setids)
+            elif word.startswith('ELSET'):
+                params_map = get_param_map(word, required_keys=['ELSET'])
+                setids = read_set(f, params_map)
+                name = params_map['ELSET']
+                if name not in elsets:
+                    elsets[name] = []
+                elsets[name].append(setids)
+            else:
+                pass
+
+    return points, cells, nsets, elsets
+
+def _read_nodes(f, points):
+    while True:
+        last_pos = f.tell()
+        line = f.readline().decode("utf-8")
+        if line.startswith("*"):
+            break;
+        sline = line.strip().split(',')
+        points = numpy.append(points,sline)
+        
+    f.seek(last_pos)
+    return points
+
+def _read_cells(f, line0, cells):
+    sline = line0.split(',')[1:]
+    etype_sline = sline[0]
+    assert 'TYPE' in etype_sline, etype_sline
+    etype = etype_sline.split('=')[1]
+    if etype not in abaqus_to_meshio_type:
+        msg = "Element type not available: " + etype
+        raise RuntimeError(msg)
+    t = abaqus_to_meshio_type[etype]
+    num_nodes_per_elem = num_nodes_per_cell[t]
+    if t not in cells:
+        cells[t] = []
+    while True:
+        last_pos = f.tell()
+        line = f.readline().decode("utf-8")
+        if line.startswith("*"):
+            break;
+        data = [int(k) for k in filter(None, line.split(','))]
+        print data
+
+        cells[t].append(data[-num_nodes_per_elem:])
+
+    # convert to numpy arrays
+    # Subtract one to account for the fact that python indices are
+    # 0-based.
+    for key in cells:
+        cells[key] = numpy.array(cells[key], dtype=int)
+        cells[key] -= 1
+
+    f.seek(last_pos)
+    return cells
+
+def get_param_map(word, required_keys=None):
+    """
+    get the optional arguments on a line
+
+    Example
+    -------
+    >>> iline = 0
+    >>> word = 'elset,instance=dummy2,generate'
+    >>> params = get_param_map(iline, word, required_keys=['instance'])
+    params = {
+        'elset' : None,
+        'instance' : 'dummy2,
+        'generate' : None,
+    }
+    """
+    if required_keys is None:
+        required_keys = []
+    words = word.split(',')
+    param_map = {}
+    for wordi in words:
+        if '=' not in wordi:
+            key = wordi.strip()
+            value = None
+        else:
+            sword = wordi.split('=')
+            assert len(sword) == 2, sword
+            key = sword[0].strip()
+            value = sword[1].strip()
+        param_map[key] = value
+
+    msg = ''
+    for key in required_keys:
+        if key not in param_map:
+            msg += '%r not found in %r\n' % (key, word)
+    if msg:
+        raise RuntimeError(msg)
+    return param_map
+
+def read_set(f, params_map):
+    """reads a set"""
+    set_ids=[]
+    while True:
+        last_pos = f.tell()
+        line = f.readline().decode("utf-8")
+        if line.startswith("*"):
+            break;
+        set_ids += line.strip(', ').split(',')
+        
+    if 'generate' in params_map:
+        assert len(set_ids) == 3, set_ids
+        set_ids = numpy.arange(int(set_ids[0]), int(set_ids[1]), int(set_ids[2]))
+    else:
+        try:
+            set_ids = numpy.unique(numpy.array(set_ids, dtype='int32'))
+        except ValueError:
+            print(set_ids)
+            raise
+    f.seek(last_pos)
+    return set_ids
+
+def write(filename,points,cells):
+    with open(filename, "wb") as f:
+        f.write('*Heading\n')
+        f.write(" abaqus DataFile Version 4.2\n".encode("utf-8"))
+        f.write("written by meshio v{}\n".format(__version__).encode("utf-8"))
+        f.write('*Node\n'.encode("utf-8"))
+        for k, x in enumerate(points):
+            f.write(
+                "{} {!r} {!r} {!r}\n".format(k + 1, x[0], x[1], x[2]).encode("utf-8")
+            )
+        for cell_type, node_idcs in cells.items():
+            f.write('*Element,type=%s\n'+ meshio_to_abaqus_type[cell_type])
+            for eid, elem in zip(eids, elems):
+                #print(elem)
+                nids_strs = (str(nid) for nid in elem.tolist())
+                #abq_file.write(str(eid) + ','.join(nids_strs) + '\n')
+                f.write(','.join(nids_strs) + '\n')
+        f.write('*endpart')

--- a/meshio/abaqus_io.py
+++ b/meshio/abaqus_io.py
@@ -151,7 +151,7 @@ def _read_nodes(f, point_gid, points):
         data = [float(k) for k in filter(None, line.strip().split(','))]
         point_gid = numpy.append( point_gid, int(data[0]) )
         points = numpy.append(points,data[-3:])
-        
+
     f.seek(last_pos)
     return points, point_gid
 

--- a/meshio/abaqus_io.py
+++ b/meshio/abaqus_io.py
@@ -250,15 +250,27 @@ def read_set(f, params_map):
     f.seek(last_pos)
     return set_ids
 
-def write(filename,points,cells):
+def write(
+    filename,
+    points,
+    cells,
+    point_data=None,
+    cell_data=None,
+    field_data=None,
+    write_binary=True,
+):
+    point_data = {} if point_data is None else point_data
+    cell_data = {} if cell_data is None else cell_data
+    field_data = {} if field_data is None else field_data
+    
     with open(filename, "wt") as f:
         f.write('*Heading\n')
-        f.write(" Abaqus DataFile Version 6.14\n".encode("utf-8"))
-        f.write("written by meshio v{}\n".format(__version__).encode("utf-8"))
-        f.write('*Node\n'.encode("utf-8"))
+        f.write(" Abaqus DataFile Version 6.14\n")
+        f.write("written by meshio v{}\n".format(__version__))
+        f.write('*Node\n')
         for k, x in enumerate(points):
             f.write(
-                "{}, {!r}, {!r}, {!r}\n".format(k + 1, x[0], x[1], x[2]).encode("utf-8")
+                "{}, {!r}, {!r}, {!r}\n".format(k + 1, x[0], x[1], x[2])
             )
         eid = 0
         for cell_type, node_idcs in cells.items():

--- a/meshio/abaqus_io.py
+++ b/meshio/abaqus_io.py
@@ -252,20 +252,20 @@ def read_set(f, params_map):
     return set_ids
 
 def write(filename,points,cells):
-    with open(filename, "wb") as f:
+    with open(filename, "wt") as f:
         f.write('*Heading\n')
-        f.write(" abaqus DataFile Version 4.2\n".encode("utf-8"))
+        f.write(" Abaqus DataFile Version 6.14\n".encode("utf-8"))
         f.write("written by meshio v{}\n".format(__version__).encode("utf-8"))
         f.write('*Node\n'.encode("utf-8"))
         for k, x in enumerate(points):
             f.write(
-                "{} {!r} {!r} {!r}\n".format(k + 1, x[0], x[1], x[2]).encode("utf-8")
+                "{}, {!r}, {!r}, {!r}\n".format(k + 1, x[0], x[1], x[2]).encode("utf-8")
             )
+        eid = 0
         for cell_type, node_idcs in cells.items():
-            f.write('*Element,type=%s\n'+ meshio_to_abaqus_type[cell_type])
-            for eid, elem in zip(eids, elems):
-                #print(elem)
-                nids_strs = (str(nid) for nid in elem.tolist())
-                #abq_file.write(str(eid) + ','.join(nids_strs) + '\n')
-                f.write(','.join(nids_strs) + '\n')
-        f.write('*endpart')
+            f.write('*Element,type='+ meshio_to_abaqus_type[cell_type]+'\n')
+            for row in node_idcs:
+                eid+=1
+                nids_strs = (str(nid+1) for nid in row.tolist())
+                f.write(str(eid) + ',' + ','.join(nids_strs) + '\n')
+        f.write('*end')

--- a/meshio/abaqus_io.py
+++ b/meshio/abaqus_io.py
@@ -106,7 +106,7 @@ def read_buffer(f):
     point_gid = numpy.array([], dtype=int )
 
     while True:
-        line = f.readline().decode("utf-8")
+        line = f.readline()
         if not line:
             # EOF
             break
@@ -138,15 +138,14 @@ def read_buffer(f):
             else:
                 pass
 
-    num_nodes = len(points)/3
-    points = numpy.reshape(points, (num_nodes,3))
+    points = numpy.reshape(points, (-1,3))
     cells = _scan_cells(point_gid, cells)
     return points, cells, point_data, cell_data, field_data
 
 def _read_nodes(f, point_gid, points):
     while True:
         last_pos = f.tell()
-        line = f.readline().decode("utf-8")
+        line = f.readline()
         if line.startswith("*"):
             break;
         data = [float(k) for k in filter(None, line.strip().split(','))]
@@ -170,7 +169,7 @@ def _read_cells(f, line0, cells):
         cells[t] = []
     while True:
         last_pos = f.tell()
-        line = f.readline().decode("utf-8")
+        line = f.readline()
         if line.startswith("*"):
             break;
         data = [int(k) for k in filter(None, line.split(','))]
@@ -186,7 +185,7 @@ def _read_cells(f, line0, cells):
     return cells
 
 def _scan_cells(point_gid, cells):
-    for arr in cells.itervalues():
+    for arr in cells.values():
         for value in numpy.nditer(arr,op_flags=['readwrite'] ):
             value[...] = numpy.flatnonzero(point_gid == value)[0]
     return cells
@@ -234,7 +233,7 @@ def read_set(f, params_map):
     set_ids=[]
     while True:
         last_pos = f.tell()
-        line = f.readline().decode("utf-8")
+        line = f.readline()
         if line.startswith("*"):
             break;
         set_ids += line.strip(', ').split(',')

--- a/meshio/helpers.py
+++ b/meshio/helpers.py
@@ -79,7 +79,7 @@ _extension_to_filetype = {
     ".vtk": "vtk-binary",
     ".xdmf": "xdmf",
     ".xmf": "xdmf",
-	".inp": "abaqus-inp",
+    ".inp": "abaqus-inp",
 }
 
 
@@ -278,6 +278,12 @@ def write(
             point_data=point_data,
             cell_data=cell_data,
             field_data=field_data,
+        )
+    elif file_format == "abaqus-inp":
+        abaqus_io.write(
+            filename,
+            points,
+            cells
         )
     else:
         assert file_format == "exodus", "Unknown file format '{}' of '{}'.".format(

--- a/meshio/helpers.py
+++ b/meshio/helpers.py
@@ -15,6 +15,7 @@ from . import stl_io
 from . import vtk_io
 from . import vtu_io
 from . import xdmf_io
+from . import abaqus_io
 
 input_filetypes = [
     "ansys",
@@ -34,6 +35,7 @@ input_filetypes = [
     "vtu-ascii",
     "vtu-binary",
     "xdmf",
+	"abaqus-inp",
 ]
 
 output_filetypes = [
@@ -55,6 +57,7 @@ output_filetypes = [
     "vtu-ascii",
     "vtu-binary",
     "xdmf",
+	"abaqus-inp",
 ]
 
 _extension_to_filetype = {
@@ -76,6 +79,7 @@ _extension_to_filetype = {
     ".vtk": "vtk-binary",
     ".xdmf": "xdmf",
     ".xmf": "xdmf",
+	".inp": "abaqus-inp",
 }
 
 
@@ -136,6 +140,8 @@ def read(filename, file_format=None):
         #
         "xdmf": xdmf_io,
         "exodus": exodus_io,
+		#
+        "abaqus-inp": abaqus_io,
     }
 
     assert file_format in format_to_reader, "Unknown file format '{}' of '{}'.".format(

--- a/meshio/helpers.py
+++ b/meshio/helpers.py
@@ -18,6 +18,7 @@ from . import xdmf_io
 from . import abaqus_io
 
 input_filetypes = [
+    "abaqus-inp",
     "ansys",
     "exodus",
     "gmsh-ascii",
@@ -35,10 +36,10 @@ input_filetypes = [
     "vtu-ascii",
     "vtu-binary",
     "xdmf",
-	"abaqus-inp",
 ]
 
 output_filetypes = [
+    "abaqus-inp",
     "ansys-ascii",
     "ansys-binary",
     "exodus",
@@ -57,7 +58,6 @@ output_filetypes = [
     "vtu-ascii",
     "vtu-binary",
     "xdmf",
-	"abaqus-inp",
 ]
 
 _extension_to_filetype = {
@@ -140,7 +140,7 @@ def read(filename, file_format=None):
         #
         "xdmf": xdmf_io,
         "exodus": exodus_io,
-		#
+        #
         "abaqus-inp": abaqus_io,
     }
 

--- a/meshio/helpers.py
+++ b/meshio/helpers.py
@@ -287,7 +287,6 @@ def write(
             point_data=point_data,
             cell_data=cell_data,
             field_data=field_data,
-            write_binary=False,
         )
     else:
         assert file_format == "exodus", "Unknown file format '{}' of '{}'.".format(

--- a/meshio/helpers.py
+++ b/meshio/helpers.py
@@ -283,7 +283,11 @@ def write(
         abaqus_io.write(
             filename,
             points,
-            cells
+            cells,
+            point_data=point_data,
+            cell_data=cell_data,
+            field_data=field_data,
+            write_binary=False,
         )
     else:
         assert file_format == "exodus", "Unknown file format '{}' of '{}'.".format(

--- a/test/test_abaqus.py
+++ b/test/test_abaqus.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+import pytest
+
+import meshio
+
+import helpers
+
+
+@pytest.mark.parametrize(
+    "mesh",
+    [
+        helpers.tri_mesh,
+        helpers.triangle6_mesh,
+        helpers.quad_mesh,
+        helpers.quad8_mesh,
+        helpers.tri_quad_mesh,
+        helpers.tet_mesh,
+        helpers.tet10_mesh,
+        helpers.hex_mesh,
+        helpers.hex20_mesh,
+    ],
+)
+
+def test(mesh):
+    def writer(*args, **kwargs):
+        return meshio.abaqus_io.write(*args, **kwargs)
+
+    helpers.write_read(writer, meshio.abaqus_io.read, mesh, 1.0e-15)
+    return

--- a/test/test_abaqus.py
+++ b/test/test_abaqus.py
@@ -21,7 +21,6 @@ import helpers
         helpers.hex20_mesh,
     ],
 )
-
 def test(mesh):
     def writer(*args, **kwargs):
         return meshio.abaqus_io.write(*args, **kwargs)

--- a/tools/meshio-convert
+++ b/tools/meshio-convert
@@ -87,7 +87,7 @@ def _parse_options():
         "--input-format",
         "-i",
         type=str,
-        choices=meshio.input_filetypes,
+        choices=meshio.helpers.input_filetypes,
         help="input file format",
         default=None,
     )
@@ -96,7 +96,7 @@ def _parse_options():
         "--output-format",
         "-o",
         type=str,
-        choices=meshio.output_filetypes,
+        choices=meshio.helpers.output_filetypes,
         help="output file format",
         default=None,
     )


### PR DESCRIPTION
Enable ABAQUS inp files' input and output. 
*  Only mesh information (*Node and *Element) are considered
*  Pytest passed
