### PR TITLE
corrected test that 3D mesh is really 2D with z=0

### DIFF
--- a/meshio/svg_io.py
+++ b/meshio/svg_io.py
@@ -7,11 +7,9 @@ def write(filename, mesh):
     from lxml import etree as ET
 
     if mesh.points.shape[1] == 3:
-        assert (
-            numpy.allclose(mesh.points[:, 2], 0.0, rtol=0.0, atol=1.0e-14)
-        ), "SVG can only handle flat 2D meshes (shape: {})".format(
-            mesh.points.shape
-        )
+        assert numpy.allclose(
+            mesh.points[:, 2], 0.0, rtol=0.0, atol=1.0e-14
+        ), "SVG can only handle flat 2D meshes (shape: {})".format(mesh.points.shape)
 
     pts = mesh.points[:, :2].copy()
     pts[:, 1] = numpy.max(pts[:, 1]) - pts[:, 1]

--- a/meshio/svg_io.py
+++ b/meshio/svg_io.py
@@ -8,7 +8,7 @@ def write(filename, mesh):
 
     if mesh.points.shape[1] == 3:
         assert (
-            numpy.all(mesh.points[:, 2]) < 1.0e-14
+            numpy.allclose(mesh.points[:, 2], 0.0, rtol=0.0, atol=1.0e-14)
         ), "SVG can only handle flat 2D meshes (shape: {})".format(
             mesh.points.shape
         )


### PR DESCRIPTION
I think `all(z)` just tests that all `z` are truthy, i.e. nonzero in a floating way, and `False < 1.0e14` is `True`, so current test passes if some `z` are falsy, i.e. zero.