### PR TITLE
shlex.split PhysicalNames to accept spaces

### DIFF
--- a/meshio/gmsh_io.py
+++ b/meshio/gmsh_io.py
@@ -195,9 +195,7 @@ def _read_physical_names(f, field_data):
     for _ in range(num_phys_names):
         line = shlex.split(f.readline().decode("utf-8"))
         key = line[2]
-        phys_group = int(line[1])
-        phys_dim = int(line[0])
-        value = numpy.array([phys_group, phys_dim], dtype=int)
+        value = numpy.array(line[1::-1], dtype=int)
         field_data[key] = value
     line = f.readline().decode("utf-8")
     assert line.strip() == "$EndPhysicalNames"

--- a/meshio/gmsh_io.py
+++ b/meshio/gmsh_io.py
@@ -5,6 +5,7 @@ I/O for Gmsh's msh format, cf.
 <http://gmsh.info//doc/texinfo/gmsh.html#File-formats>.
 """
 import logging
+import shlex
 import struct
 
 import numpy
@@ -192,10 +193,10 @@ def _read_physical_names(f, field_data):
     line = f.readline().decode("utf-8")
     num_phys_names = int(line)
     for _ in range(num_phys_names):
-        line = f.readline().decode("utf-8")
-        key = line.split(" ")[2].replace('"', "").replace("\n", "")
-        phys_group = int(line.split(" ")[1])
-        phys_dim = int(line.split(" ")[0])
+        line = shlex.split(f.readline().decode("utf-8"))
+        key = line[2]
+        phys_group = int(line[1])
+        phys_dim = int(line[0])
         value = numpy.array([phys_group, phys_dim], dtype=int)
         field_data[key] = value
     line = f.readline().decode("utf-8")


### PR DESCRIPTION
This aims to fix #281.

I haven't been able to test it properly because I've got Gmsh 4 which outputs MSH4 #280.

The idea of using `shlex.split` instead of `str.split` is from https://stackoverflow.com/questions/79968/split-a-string-by-spaces-preserving-quoted-substrings-in-python.