### PR TITLE
Add possibility to save 2D meshes in XDMF (avoid embedding into 3D)

### DIFF
--- a/meshio/xdmf_io.py
+++ b/meshio/xdmf_io.py
@@ -385,9 +385,9 @@ class XdmfReader(object):
 
 
 class XdmfWriter(object):
-    def __init__(self, filename, mesh,
-                 pretty_xml=True, data_format="HDF",
-                 save_as_planar_mesh=False):
+    def __init__(
+        self, filename, mesh, pretty_xml=True, data_format="HDF", save_as_planar=False
+    ):
         from lxml import etree as ET
 
         assert data_format in ["XML", "Binary", "HDF"], (
@@ -410,7 +410,7 @@ class XdmfWriter(object):
         domain = ET.SubElement(xdmf_file, "Domain")
         grid = ET.SubElement(domain, "Grid", Name="Grid")
 
-        self.points(grid, mesh.points, save_as_planar_mesh)
+        self.points(grid, mesh.points, save_as_planar)
         self.cells(mesh.cells, grid)
         self.point_data(mesh.point_data, grid)
         self.cell_data(mesh.cell_data, grid)
@@ -442,15 +442,15 @@ class XdmfWriter(object):
         self.h5_file.create_dataset(name, data=data)
         return self.h5_filename + ":/" + name
 
-    def points(self, grid, points, save_as_planar_mesh):
+    def points(self, grid, points, save_as_planar):
         from lxml import etree as ET
 
-        geo_type = "XYZ" # default GeometryType (all meshes are 3D)
-        if save_as_planar_mesh:
+        geo_type = "XYZ"  # default GeometryType (all meshes are 3D)
+        if save_as_planar:
             # Trim Z-coordinate
-            geo_type = geo_type[:-1]
-            assert (numpy.zeros(len(points)) == points[:, -1]).all(), \
-              "Mesh can be saved as planar only if it is defined at `Z = 0`"
+            geo_type = "XY"
+            # assert (numpy.zeros(len(points)) == points[:, -1]).all(), \
+            #  "Mesh can be saved as planar only if it is defined at `Z = 0`"
             points = points[:, :-1]
         geo = ET.SubElement(grid, "Geometry", GeometryType=geo_type)
         dt, prec = numpy_to_xdmf_dtype[points.dtype.name]

--- a/meshio/xdmf_io.py
+++ b/meshio/xdmf_io.py
@@ -385,7 +385,9 @@ class XdmfReader(object):
 
 
 class XdmfWriter(object):
-    def __init__(self, filename, mesh, pretty_xml=True, data_format="HDF"):
+    def __init__(self, filename, mesh,
+                 pretty_xml=True, data_format="HDF",
+                 save_as_planar_mesh=False):
         from lxml import etree as ET
 
         assert data_format in ["XML", "Binary", "HDF"], (
@@ -408,7 +410,7 @@ class XdmfWriter(object):
         domain = ET.SubElement(xdmf_file, "Domain")
         grid = ET.SubElement(domain, "Grid", Name="Grid")
 
-        self.points(grid, mesh.points)
+        self.points(grid, mesh.points, save_as_planar_mesh)
         self.cells(mesh.cells, grid)
         self.point_data(mesh.point_data, grid)
         self.cell_data(mesh.cell_data, grid)
@@ -440,10 +442,17 @@ class XdmfWriter(object):
         self.h5_file.create_dataset(name, data=data)
         return self.h5_filename + ":/" + name
 
-    def points(self, grid, points):
+    def points(self, grid, points, save_as_planar_mesh):
         from lxml import etree as ET
 
-        geo = ET.SubElement(grid, "Geometry", GeometryType="XYZ")
+        geo_type = "XYZ" # default GeometryType (all meshes are 3D)
+        if save_as_planar_mesh:
+            # Trim Z-coordinate
+            geo_type = geo_type[:-1]
+            assert (numpy.zeros(len(points)) == points[:, -1]).all(), \
+              "Mesh can be saved as planar only if it is defined at `Z = 0`"
+            points = points[:, :-1]
+        geo = ET.SubElement(grid, "Geometry", GeometryType=geo_type)
         dt, prec = numpy_to_xdmf_dtype[points.dtype.name]
         dim = "{} {}".format(*points.shape)
         data_item = ET.SubElement(


### PR DESCRIPTION
Users can opt to save a mesh in XDMF as being truly planar, i.e. with `GeometryType="XY"` and thus with geometric dimension `== 2`. Such mesh can be safely re-read through https://github.com/nschloe/meshio/blob/ecd790a2fbd3d8bb5c7048b5920dc1caf929be00/meshio/xdmf_io.py#L303 

See #294 and https://github.com/FEniCS/dolfinx/issues/159