### PR TITLE
read physical tags from MSH4

### DIFF
--- a/meshio/msh_io/main.py
+++ b/meshio/msh_io/main.py
@@ -14,8 +14,8 @@ def read(filename):
 
 
 def read_buffer(f):
-    # The format is specified at
-    # <http://gmsh.info//doc/texinfo/gmsh.html#MSH-ASCII-file-format>.
+    # The various versions of the format are specified at
+    # <http://gmsh.info//doc/texinfo/gmsh.html#File-formats>.
 
     line = f.readline().decode("utf-8")
     assert line.strip() == "$MeshFormat"

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 """
-I/O for Gmsh's msh format, cf.
-<http://gmsh.info//doc/texinfo/gmsh.html#File-formats>.
+I/O for Gmsh's msh format (version 4), cf.
+<http://gmsh.info//doc/texinfo/gmsh.html#MSH-file-format-_0028version-4_0029>.
 """
 from ctypes import c_ulong, c_double, c_int
 import logging
@@ -26,7 +26,7 @@ from ..common import num_nodes_per_cell, cell_data_from_raw, raw_from_cell_data
 
 def read_buffer(f, is_ascii, int_size, data_size):
     # The format is specified at
-    # <http://gmsh.info//doc/texinfo/gmsh.html#MSH-ASCII-file-format>.
+    # <http://gmsh.info//doc/texinfo/gmsh.html#MSH-file-format-_0028version-4_0029>.
 
     # Initialize the optional data fields
     points = []

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -53,7 +53,9 @@ def read_buffer(f, is_ascii, int_size, data_size):
         elif environ == "Nodes":
             points, point_tags = _read_nodes(f, is_ascii, int_size, data_size)
         elif environ == "Elements":
-            cells, cell_tags = _read_cells(f, point_tags, int_size, is_ascii, physical_tags)
+            cells, cell_tags = _read_cells(
+                f, point_tags, int_size, is_ascii, physical_tags
+            )
         elif environ == "Periodic":
             periodic = _read_periodic(f)
         elif environ == "NodeData":

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -47,16 +47,16 @@ def read_buffer(f, is_ascii, int_size, data_size):
 
         if environ == "PhysicalNames":
             _read_physical_names(f, field_data)
+        elif environ == "Entities":
+            physical_tags = _read_entities(  # noqa F841
+                f, physical_tags, is_ascii, int_size, data_size
+            )
         elif environ == "Nodes":
             points, point_tags = _read_nodes(f, is_ascii, int_size, data_size)
         elif environ == "Elements":
             cells = _read_cells(f, point_tags, int_size, is_ascii)
         elif environ == "Periodic":
             periodic = _read_periodic(f)
-        elif environ == "Entities":
-            physical_tags = _read_entities(  # noqa F841
-                f, is_ascii, int_size, data_size
-            )
         elif environ == "NodeData":
             _read_data(f, "NodeData", point_data, int_size, data_size, is_ascii)
         elif environ == "ElementData":

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -203,8 +203,7 @@ def _read_cells(f, point_tags, int_size, is_ascii, physical_tags):
     data = [(physical_tag, tpe, itags[d[:, 1:]]) for physical_tag, tpe, d in data]
 
     cells = {}
-    for item in data:
-        physical_tag, key, values = item
+    for physical_tag, key, values in data:
         if key in cells:
             cells[key] = numpy.concatenate([cells[key], values])
         else:

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -49,7 +49,7 @@ def read_buffer(f, is_ascii, int_size, data_size):
             _read_physical_names(f, field_data)
         elif environ == "Entities":
             physical_tags = _read_entities(  # noqa F841
-                f, physical_tags, is_ascii, int_size, data_size
+                f, is_ascii, int_size, data_size
             )
         elif environ == "Nodes":
             points, point_tags = _read_nodes(f, is_ascii, int_size, data_size)

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -53,7 +53,7 @@ def read_buffer(f, is_ascii, int_size, data_size):
         elif environ == "Nodes":
             points, point_tags = _read_nodes(f, is_ascii, int_size, data_size)
         elif environ == "Elements":
-            cells, cell_physical_tags = _read_cells(f, point_tags, int_size, is_ascii, physical_tags)
+            cells, cell_tags = _read_cells(f, point_tags, int_size, is_ascii, physical_tags)
         elif environ == "Periodic":
             periodic = _read_periodic(f)
         elif environ == "NodeData":
@@ -73,14 +73,7 @@ def read_buffer(f, is_ascii, int_size, data_size):
                 line = f.readline().decode("utf-8").strip()
 
     cell_data = cell_data_from_raw(cells, cell_data_raw)
-
-    # merge cell_tags into cell_data
-    for key, tag_dict in cell_tags.items():
-        if key not in cell_data:
-            cell_data[key] = {}
-        for name, item_list in tag_dict.items():
-            assert name not in cell_data[key]
-            cell_data[key][name] = item_list
+    cell_data.update(cell_tags)
 
     return Mesh(
         points,

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -179,7 +179,9 @@ def _read_cells(f, point_tags, int_size, is_ascii):
         num_ele, = fromfile(f, c_ulong, 1)
         tpe = _gmsh_to_meshio_type[type_ele]
         num_nodes_per_ele = num_nodes_per_cell[tpe]
-        d = fromfile(f, c_int, int(num_ele * (1 + num_nodes_per_ele))).reshape((num_ele, -1))
+        d = fromfile(f, c_int, int(num_ele * (1 + num_nodes_per_ele))).reshape(
+            (num_ele, -1)
+        )
         data.append((tpe, d))
 
     if not is_ascii:
@@ -239,6 +241,7 @@ def _read_cells(f, point_tags, int_size, is_ascii):
     m = numpy.max(point_tags + 1)
     itags = -numpy.ones(m, dtype=int)
     itags[point_tags] = numpy.arange(len(point_tags))
+
     # Note that the first column in the data array is the element tag; discard it.
     data = [(tpe, itags[d[:, 1:]]) for tpe, d in data]
 

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -192,51 +192,6 @@ def _read_cells(f, point_tags, int_size, is_ascii, physical_tags):
     line = f.readline().decode("utf-8")
     assert line.strip() == "$EndElements"
 
-    # if is_ascii:
-
-    #     for k in range(num_entity_blocks):
-    #         line = f.readline().decode("utf-8")
-    #         # tagEntity(int) dimEntity(int) typeEle(int) numElements(unsigned long)
-    #         tag_entity, dim_entity, type_ele, num_elements = [
-    #             int(k) for k in line.split()
-    #         ]
-    #         tpe = _gmsh_to_meshio_type[type_ele]
-    #         num_nodes_per_ele = num_nodes_per_cell[tpe]
-    #         d = numpy.empty((num_elements, num_nodes_per_ele + 1), dtype=int)
-    #         idx = 0
-    #         for i in range(num_elements):
-    #             # tag(int) numVert(int)[...]
-    #             line = f.readline().decode("utf-8")
-    #             items = line.split()
-    #             d[idx] = [int(item) for item in items]
-    #             idx += 1
-    #         assert idx == num_elements
-    #         data.append((tpe, d))
-
-    #     line = f.readline().decode("utf-8")
-    #     assert line.strip() == "$EndElements"
-    # else:
-
-    #     for k in range(num_entity_blocks):
-    #         # tagEntity(int) dimEntity(int) typeEle(int) numEle(unsigned long)
-    #         _, _, type_ele = numpy.fromfile(f, count=3, dtype=c_int)
-
-    #         tpe = _gmsh_to_meshio_type[type_ele]
-    #         num_nodes_per_ele = num_nodes_per_cell[tpe]
-
-    #         num_ele = numpy.fromfile(f, count=1, dtype=c_ulong)
-
-    #         d = numpy.fromfile(
-    #             f, count=int(num_ele * (num_nodes_per_ele + 1)), dtype=c_int
-    #         ).reshape(int(num_ele), -1)
-
-    #         data.append((tpe, d))
-
-    #     line = f.readline().decode("utf-8")
-    #     assert line == "\n"
-    #     line = f.readline().decode("utf-8")
-    #     assert line.strip() == "$EndElements"
-
     # The msh4 elements array refers to the nodes by their tag, not the index. All other
     # mesh formats use the index, which is far more efficient, too. Hence,
     # unfortunately, we have to do a fairly expensive conversion here.

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -113,7 +113,6 @@ def _read_entities(f, is_ascii, int_size, data_size):
         assert line == ""
     line = f.readline().decode("utf-8").strip()
     assert line == "$EndEntities"
-    print('Physical tags:', physical_tags)
     return physical_tags
 
 
@@ -167,57 +166,72 @@ def _read_nodes(f, is_ascii, int_size, data_size):
 
 
 def _read_cells(f, point_tags, int_size, is_ascii):
-    if is_ascii:
-        # numEntityBlocks(unsigned long) numElements(unsigned long)
-        line = f.readline().decode("utf-8")
-        num_entity_blocks, total_num_elements = [int(k) for k in line.split()]
+    fromfile = partial(numpy.fromfile, sep=" " if is_ascii else "")
 
-        data = []
-        for k in range(num_entity_blocks):
-            line = f.readline().decode("utf-8")
-            # tagEntity(int) dimEntity(int) typeEle(int) numElements(unsigned long)
-            tag_entity, dim_entity, type_ele, num_elements = [
-                int(k) for k in line.split()
-            ]
-            tpe = _gmsh_to_meshio_type[type_ele]
-            num_nodes_per_ele = num_nodes_per_cell[tpe]
-            d = numpy.empty((num_elements, num_nodes_per_ele + 1), dtype=int)
-            idx = 0
-            for i in range(num_elements):
-                # tag(int) numVert(int)[...]
-                line = f.readline().decode("utf-8")
-                items = line.split()
-                d[idx] = [int(item) for item in items]
-                idx += 1
-            assert idx == num_elements
-            data.append((tpe, d))
+    # numEntityBlocks(unsigned long) numElements(unsigned long)
+    num_entity_blocks, total_num_elements = fromfile(f, c_ulong, 2)
 
-        line = f.readline().decode("utf-8")
-        assert line.strip() == "$EndElements"
-    else:
-        # numEntityBlocks(unsigned long) numElements(unsigned long)
-        num_entity_blocks, _ = numpy.fromfile(f, count=2, dtype=c_ulong)
+    data = []
 
-        data = []
-        for k in range(num_entity_blocks):
-            # tagEntity(int) dimEntity(int) typeEle(int) numEle(unsigned long)
-            _, _, type_ele = numpy.fromfile(f, count=3, dtype=c_int)
+    for k in range(num_entity_blocks):
+        # tagEntity(int) dimEntity(int) typeEle(int) numElements(unsigned long)
+        tag_entity, dim_entity, type_ele = fromfile(f, c_int, 3)
+        num_ele, = fromfile(f, c_ulong, 1)
+        tpe = _gmsh_to_meshio_type[type_ele]
+        num_nodes_per_ele = num_nodes_per_cell[tpe]
+        d = fromfile(f, c_int, int(num_ele * (1 + num_nodes_per_ele))).reshape((num_ele, -1))
+        data.append((tpe, d))
 
-            tpe = _gmsh_to_meshio_type[type_ele]
-            num_nodes_per_ele = num_nodes_per_cell[tpe]
-
-            num_ele = numpy.fromfile(f, count=1, dtype=c_ulong)
-
-            d = numpy.fromfile(
-                f, count=int(num_ele * (num_nodes_per_ele + 1)), dtype=c_int
-            ).reshape(int(num_ele), -1)
-
-            data.append((tpe, d))
-
+    if not is_ascii:
         line = f.readline().decode("utf-8")
         assert line == "\n"
-        line = f.readline().decode("utf-8")
-        assert line.strip() == "$EndElements"
+    line = f.readline().decode("utf-8")
+    assert line.strip() == "$EndElements"
+
+    # if is_ascii:
+
+    #     for k in range(num_entity_blocks):
+    #         line = f.readline().decode("utf-8")
+    #         # tagEntity(int) dimEntity(int) typeEle(int) numElements(unsigned long)
+    #         tag_entity, dim_entity, type_ele, num_elements = [
+    #             int(k) for k in line.split()
+    #         ]
+    #         tpe = _gmsh_to_meshio_type[type_ele]
+    #         num_nodes_per_ele = num_nodes_per_cell[tpe]
+    #         d = numpy.empty((num_elements, num_nodes_per_ele + 1), dtype=int)
+    #         idx = 0
+    #         for i in range(num_elements):
+    #             # tag(int) numVert(int)[...]
+    #             line = f.readline().decode("utf-8")
+    #             items = line.split()
+    #             d[idx] = [int(item) for item in items]
+    #             idx += 1
+    #         assert idx == num_elements
+    #         data.append((tpe, d))
+
+    #     line = f.readline().decode("utf-8")
+    #     assert line.strip() == "$EndElements"
+    # else:
+
+    #     for k in range(num_entity_blocks):
+    #         # tagEntity(int) dimEntity(int) typeEle(int) numEle(unsigned long)
+    #         _, _, type_ele = numpy.fromfile(f, count=3, dtype=c_int)
+
+    #         tpe = _gmsh_to_meshio_type[type_ele]
+    #         num_nodes_per_ele = num_nodes_per_cell[tpe]
+
+    #         num_ele = numpy.fromfile(f, count=1, dtype=c_ulong)
+
+    #         d = numpy.fromfile(
+    #             f, count=int(num_ele * (num_nodes_per_ele + 1)), dtype=c_int
+    #         ).reshape(int(num_ele), -1)
+
+    #         data.append((tpe, d))
+
+    #     line = f.readline().decode("utf-8")
+    #     assert line == "\n"
+    #     line = f.readline().decode("utf-8")
+    #     assert line.strip() == "$EndElements"
 
     # The msh4 elements array refers to the nodes by their tag, not the index. All other
     # mesh formats use the index, which is far more efficient, too. Hence,

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -105,11 +105,15 @@ def _read_entities(f, is_ascii, int_size, data_size):
             num_physicals, = fromfile(f, c_ulong, 1)
             physical_tags[d][tag] = list(fromfile(f, c_int, num_physicals))
             if d > 0:  # discard tagBREP{Vert,Curve,Surfaces}
-                num_BREP_vert, = fromfile(f, c_ulong, 1)
-                fromfile(f, c_int, num_BREP_vert)
+                num_BREP_, = fromfile(f, c_ulong, 1)
+                fromfile(f, c_int, num_BREP_)
 
+    if not is_ascii:
+        line = f.readline().decode("utf-8").strip()
+        assert line == ""
     line = f.readline().decode("utf-8").strip()
     assert line == "$EndEntities"
+    print('Physical tags:', physical_tags)
     return physical_tags
 
 

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -238,8 +238,7 @@ def _read_cells(f, point_tags, int_size, is_ascii):
     # unfortunately, we have to do a fairly expensive conversion here.
     m = numpy.max(point_tags + 1)
     itags = -numpy.ones(m, dtype=int)
-    for k, tag in enumerate(point_tags):
-        itags[tag] = k
+    itags[point_tags] = numpy.arange(len(point_tags))
     # Note that the first column in the data array is the element tag; discard it.
     data = [(tpe, itags[d[:, 1:]]) for tpe, d in data]
 

--- a/meshio/msh_io/msh4.py
+++ b/meshio/msh_io/msh4.py
@@ -185,7 +185,7 @@ def _read_cells(f, point_tags, int_size, is_ascii, physical_tags):
             data.append((None, tpe, d))
         else:
             data.append((physical_tags[dim_entity][tag_entity], tpe, d))
-            
+
     if not is_ascii:
         line = f.readline().decode("utf-8")
         assert line == "\n"


### PR DESCRIPTION
This extends the reading of MSH4 #280, including binary MSH4 #284, in particular focusing on harvesting the physical tags from the `$Entities` section (begun in #289).