### PR TITLE
Backward compatibility: make Mesh class iterable and yield points, cells, point_data, cell_data, field_data

### DIFF
--- a/meshio/mesh.py
+++ b/meshio/mesh.py
@@ -44,6 +44,12 @@ class Mesh(object):
 
         return "\n".join(lines)
 
+    def __iter__(self):
+        for value in [
+            self.points, self.cells, self.point_data, self.cell_data, self.field_data,
+        ]:
+            yield value
+
     def prune(self):
         prune_list = []
 

--- a/meshio/mesh.py
+++ b/meshio/mesh.py
@@ -46,7 +46,11 @@ class Mesh(object):
 
     def __iter__(self):
         for value in [
-            self.points, self.cells, self.point_data, self.cell_data, self.field_data,
+            self.points,
+            self.cells,
+            self.point_data,
+            self.cell_data,
+            self.field_data,
         ]:
             yield value
 


### PR DESCRIPTION
With this little hack, you could use the `mesio.read` as before:
`points, cells, point_data, cell_data, field_data = meshio.read(infile)`

Maybe this could solve some incompatibilities in some other projects depending on meshio.

What do you think? 