### PR TITLE
pad 2d vectors to 3d to write to VTK

### DIFF
--- a/meshio/vtk_io.py
+++ b/meshio/vtk_io.py
@@ -391,6 +391,15 @@ def write(filename, mesh, write_binary=True):
         mesh.points = numpy.column_stack(
             [mesh.points[:, 0], mesh.points[:, 1], numpy.zeros(mesh.points.shape[0])]
         )
+        if mesh.point_data:
+            for name, values in mesh.point_data.items():
+                if values.shape[1] == 2:
+                    logging.warning(
+                        "VTK requires 3D vectors, but 2D vectors given. "
+            "Appending 0 third component to {}.".format(name)
+        )
+                    mesh.point_data[name] = numpy.column_stack(
+                        [values[:, 0], values[:, 1], numpy.zeros(mesh.points.shape[0])])
 
     if not write_binary:
         logging.warning("VTK ASCII files are only meant for debugging.")

--- a/meshio/vtk_io.py
+++ b/meshio/vtk_io.py
@@ -384,22 +384,33 @@ def translate_cells(data, types, cell_data_raw):
 
 def write(filename, mesh, write_binary=True):
     if mesh.points.shape[1] == 2:
+
+        def pad(array):
+            return numpy.pad(array, ((0, 0), (0, 1)), "constant")
+
         logging.warning(
             "VTK requires 3D points, but 2D points given. "
             "Appending 0 third component."
         )
-        mesh.points = numpy.column_stack(
-            [mesh.points[:, 0], mesh.points[:, 1], numpy.zeros(mesh.points.shape[0])]
-        )
+        mesh.points = pad(mesh.points)
+
         if mesh.point_data:
             for name, values in mesh.point_data.items():
                 if values.shape[1] == 2:
                     logging.warning(
                         "VTK requires 3D vectors, but 2D vectors given. "
-            "Appending 0 third component to {}.".format(name)
-        )
-                    mesh.point_data[name] = numpy.column_stack(
-                        [values[:, 0], values[:, 1], numpy.zeros(mesh.points.shape[0])])
+                        "Appending 0 third component to {}.".format(name)
+                    )
+                    mesh.point_data[name] = pad(values)
+        if mesh.cell_data:
+            for t, data in mesh.cell_data.items():
+                for name, values in data.items():
+                    if values.shape[1] == 2:
+                        logging.warning(
+                            "VTK requires 3D vectors, but 2D vectors given. "
+                            "Appending 0 third component to {}.".format(name)
+                        )
+                    mesh.cell_data[t][name] = pad(mesh.cell_data[t][name])
 
     if not write_binary:
         logging.warning("VTK ASCII files are only meant for debugging.")

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -27,6 +27,7 @@ test_set = [
     helpers.add_cell_data(helpers.tri_mesh, 1),
     helpers.add_cell_data(helpers.tri_mesh, 2),
     helpers.add_cell_data(helpers.tri_mesh, 3),
+    helpers.add_cell_data(helpers.add_point_data(helpers.tri_mesh_2d, 2), 2)
 ]
 
 

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -27,7 +27,7 @@ test_set = [
     helpers.add_cell_data(helpers.tri_mesh, 1),
     helpers.add_cell_data(helpers.tri_mesh, 2),
     helpers.add_cell_data(helpers.tri_mesh, 3),
-    helpers.add_cell_data(helpers.add_point_data(helpers.tri_mesh_2d, 2), 2)
+    helpers.add_cell_data(helpers.add_point_data(helpers.tri_mesh_2d, 2), 2),
 ]
 
 


### PR DESCRIPTION
This fixes #325 for point_data and cell_data.  Doesn't touch field_data, which seems less likely.

Since the same padding operation is required for the data as for the points, it has been factored out into a function `pad` inside `vtk_io.write`.