### PR TITLE
only named arguments after *args

### DIFF
--- a/test/test_gmsh.py
+++ b/test/test_gmsh.py
@@ -78,7 +78,7 @@ def test_gmsh2(mesh, write_binary):
 )
 @pytest.mark.parametrize("write_binary", [False, True])
 def test_gmsh4(mesh, write_binary):
-    writer = partial(meshio.msh_io.write, fmt_version="2", write_binary=write_binary)
+    writer = partial(meshio.msh_io.write, fmt_version="4", write_binary=write_binary)
 
     helpers.write_read(writer, meshio.msh_io.read, mesh, 1.0e-15)
     return

--- a/test/test_gmsh.py
+++ b/test/test_gmsh.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 import copy
+from functools import partial
 import pytest
 
 import meshio
@@ -45,8 +46,7 @@ def gmsh_periodic():
 )
 @pytest.mark.parametrize("write_binary", [False, True])
 def test_gmsh2(mesh, write_binary):
-    def writer(*args, **kwargs):
-        return meshio.msh_io.write(*args, "2", write_binary=write_binary, **kwargs)
+    writer = partial(meshio.msh_io.write, fmt_version="2", write_binary=write_binary)
 
     helpers.write_read(writer, meshio.msh_io.read, mesh, 1.0e-15)
     return
@@ -78,8 +78,7 @@ def test_gmsh2(mesh, write_binary):
 )
 @pytest.mark.parametrize("write_binary", [False, True])
 def test_gmsh4(mesh, write_binary):
-    def writer(*args, **kwargs):
-        return meshio.msh_io.write(*args, "4", write_binary=write_binary, **kwargs)
+    writer = partial(meshio.msh_io.write, fmt_version="2", write_binary=write_binary)
 
     helpers.write_read(writer, meshio.msh_io.read, mesh, 1.0e-15)
     return


### PR DESCRIPTION
Maybe just me, but I found having the named positional argument `"2"` after `*args` confusing.

https://github.com/nschloe/meshio/blob/7995c68e10460aacf45af57c88c6dbf4af26b2e9/test/test_gmsh.py#L49 

Ignore if you disagree.