### PR TITLE
Read retracts write

### DIFF
--- a/test/test_gmsh.py
+++ b/test/test_gmsh.py
@@ -102,7 +102,8 @@ def test_generic_io():
         )
     ],
 )
-def test_reference_file(filename, md5, ref_sum, ref_num_cells):
+@pytest.mark.parametrize("write_binary", [False, True])
+def test_reference_file(filename, md5, ref_sum, ref_num_cells, write_binary):
     filename = helpers.download(filename, md5)
 
     mesh = meshio.read(filename)
@@ -113,3 +114,6 @@ def test_reference_file(filename, md5, ref_sum, ref_num_cells):
     assert {
         k: len(v["gmsh:physical"]) for k, v in mesh.cell_data.items()
     } == ref_num_cells
+    
+    writer = partial(meshio.msh_io.write, fmt_version="2", write_binary=write_binary)
+    helpers.write_read(writer, meshio.msh_io.read, mesh, 1.0e-15)

--- a/test/test_gmsh.py
+++ b/test/test_gmsh.py
@@ -114,6 +114,6 @@ def test_reference_file(filename, md5, ref_sum, ref_num_cells, write_binary):
     assert {
         k: len(v["gmsh:physical"]) for k, v in mesh.cell_data.items()
     } == ref_num_cells
-    
+
     writer = partial(meshio.msh_io.write, fmt_version="2", write_binary=write_binary)
     helpers.write_read(writer, meshio.msh_io.read, mesh, 1.0e-15)

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+from functools import partial
 import pytest
 
 import meshio
@@ -57,6 +58,7 @@ def test_reference_file(filename, md5, ref_sum, ref_num_cells):
     s = numpy.sum(mesh.points)
     assert abs(s - ref_sum) < tol * ref_sum
     assert len(mesh.cells["triangle"]) == ref_num_cells
+    helpers.write_read(meshio.vtk_io.write, meshio.vtk_io.read, mesh, 1.0e-15)
     return
 
 

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -50,7 +50,8 @@ def test_generic_io():
     "filename, md5, ref_sum, ref_num_cells",
     [("vtk/rbc_001.vtk", "19f431dcb07971d5f29de33d6bbed79a", 0.00031280518, 996)],
 )
-def test_reference_file(filename, md5, ref_sum, ref_num_cells):
+@pytest.mark.parametrize("write_binary", [False, True])
+def test_reference_file(filename, md5, ref_sum, ref_num_cells, write_binary):
     filename = helpers.download(filename, md5)
 
     mesh = meshio.read(filename)
@@ -58,7 +59,8 @@ def test_reference_file(filename, md5, ref_sum, ref_num_cells):
     s = numpy.sum(mesh.points)
     assert abs(s - ref_sum) < tol * ref_sum
     assert len(mesh.cells["triangle"]) == ref_num_cells
-    helpers.write_read(meshio.vtk_io.write, meshio.vtk_io.read, mesh, 1.0e-15)
+    writer = partial(meshio.vtk_io.write, write_binary=write_binary)
+    helpers.write_read(writer, meshio.vtk_io.read, mesh, 1.0e-15)
     return
 
 


### PR DESCRIPTION
So far the tests #338 #344 against the meshes from the suite #335 only test the readers, but they're also probably pretty good for testing the writers in the sense that read &sdot; write &sdot; read should produce the same as read.  This implements that for VTK and MSH2.2.