### PR TITLE
update URLs to MED documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ meshio can read and write all of the following and smoothly converts between the
  * [H5M](https://www.mcs.anl.gov/~fathom/moab-docs/h5mmain.html)
  * [Kratos/MDPA](https://github.com/KratosMultiphysics/Kratos/wiki/Input-data)
  * [Medit](https://people.sc.fsu.edu/~jburkardt/data/medit/medit.html)
- * [MED/Salome](https://docs.salome-platform.org/latest/dev/MEDCoupling/developer)
+ * [MED/Salome](https://docs.salome-platform.org/latest/dev/MEDCoupling/developer/med-file.html)
  * [Gmsh](http://gmsh.info/doc/texinfo/gmsh.html#File-formats) (versions 2 and 4)
  * [OFF](http://segeval.cs.princeton.edu/public/off_format.html)
  * [PERMAS](http://www.intes.de)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ meshio can read and write all of the following and smoothly converts between the
  * [H5M](https://www.mcs.anl.gov/~fathom/moab-docs/h5mmain.html)
  * [Kratos/MDPA](https://github.com/KratosMultiphysics/Kratos/wiki/Input-data)
  * [Medit](https://people.sc.fsu.edu/~jburkardt/data/medit/medit.html)
- * [MED/Salome](http://docs.salome-platform.org/latest/dev/MEDCoupling/med-file.html)
+ * [MED/Salome](https://docs.salome-platform.org/latest/dev/MEDCoupling/developer)
  * [Gmsh](http://gmsh.info/doc/texinfo/gmsh.html#File-formats) (versions 2 and 4)
  * [OFF](http://segeval.cs.princeton.edu/public/off_format.html)
  * [PERMAS](http://www.intes.de)

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -2,7 +2,7 @@
 #
 """
 I/O for MED/Salome, cf.
-<https://docs.salome-platform.org/latest/dev/MEDCoupling/developer/>.
+<https://docs.salome-platform.org/latest/dev/MEDCoupling/developer/med-file.html>.
 """
 import numpy
 

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -2,7 +2,7 @@
 #
 """
 I/O for MED/Salome, cf.
-<http://docs.salome-platform.org/latest/dev/MEDCoupling/med-file.html>.
+<https://docs.salome-platform.org/latest/dev/MEDCoupling/developer/>.
 """
 import numpy
 


### PR DESCRIPTION
While looking into #347, I noticed that the [URL](https://docs.salome-platform.org/latest/dev/MEDCoupling/med-file.html) for MED was 404.