### PR TITLE
WIP: read tagged subsets of elements from MED

### DIFF
--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -67,6 +67,8 @@ def read(filename):
         if families.any():
             cells[cell_type] = med_cell_type_group["NOD"][()].reshape(
                 num_nodes_per_cell[cell_type], -1).T - 1
+            if cell_type not in cell_data:
+                cell_data[cell_type] = {}
             cell_data[cell_type]["gmsh:physical"] = families
 
     return Mesh(

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -6,8 +6,8 @@ I/O for MED/Salome, cf.
 """
 import numpy
 
+from .common import num_nodes_per_cell
 from .mesh import Mesh
-
 
 # https://bitbucket.org/code_aster/codeaster-src/src/default/catalo/cataelem/Commons/mesh_types.py
 meshio_to_med_type = {
@@ -54,10 +54,10 @@ def read(filename):
     # Cells
     cells = {}
     mai = mesh["MAI"]
-    for key, med_type in meshio_to_med_type.items():
-        if med_type in mai:
-            nn = int("".join(filter(str.isdigit, med_type)))
-            cells[key] = mai[med_type]["NOD"][()].reshape(nn, -1).T - 1
+    for med_cell_type, med_cell_type_group in mai.items():
+        cell_type = med_to_meshio_type[med_cell_type]
+        cells[cell_type] = med_cell_type_group["NOD"][()].reshape(
+            num_nodes_per_cell[cell_type], -1).T - 1
 
     # Read nodal and cell data if they exist
     try:

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -69,7 +69,7 @@ def read(filename):
                 num_nodes_per_cell[cell_type], -1).T - 1
             if cell_type not in cell_data:
                 cell_data[cell_type] = {}
-            cell_data[cell_type]["gmsh:physical"] = families
+            cell_data[cell_type]["gmsh:physical"] = -families
 
     return Mesh(
         points, cells, point_data=point_data, cell_data=cell_data, field_data=field_data


### PR DESCRIPTION
This is a start on #347 'MED 4.0 to .msh or .xml with entities', i.e. being able to read MED like Gmsh does, preserving tagged subsets of elements #290.

It seems to be a bit at odds with the current implementation though, and MED is a big format which I don't claim to fully understand, so I don't want to take it too much further before resolving some of the topics in #347.