### PR TITLE
Read and write point/cell sets of a MED file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,0 @@
-# Change log
-
-## Unreleased
-
-- MED: support reading and writing point and cell sets #347 #352

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,5 @@
+# Change log
+
+## Unreleased
+
+- MED: support reading and writing point and cell sets #347 #352

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -33,27 +33,27 @@ def read(filename):
     f = h5py.File(filename, "r")
 
     # Mesh ensemble
-    ens_maa = f["ENS_MAA"]
-    meshes = ens_maa.keys()
+    mesh_ensemble = f["ENS_MAA"]
+    meshes = mesh_ensemble.keys()
     assert len(meshes) == 1, "Must only contain exactly 1 mesh"
     mesh_name = list(meshes)[0]
-    mesh = ens_maa[mesh_name]
+    mesh = mesh_ensemble[mesh_name]
 
     # Possible time-stepping
     if "NOE" not in mesh:
         # One needs NOE (node) and MAI (french maillage, meshing) data. If they
         # are not available in the mesh, check for time-steppings.
-        ts = mesh.keys()
-        assert len(ts) == 1, "Must only contain exactly 1 time-step"
-        mesh = mesh[list(ts)[0]]
+        time_step = mesh.keys()
+        assert len(time_step) == 1, "Must only contain exactly 1 time-step"
+        mesh = mesh[list(time_step)[0]]
 
     # Read nodal and cell data if they exist
     try:
-        cha = f["CHA"]  # champs (fields) in french
+        fields = f["CHA"]  # champs (fields) in french
     except KeyError:
         point_data, cell_data, field_data = {}, {}, {}
     else:
-        point_data, cell_data, field_data = _read_data(cha)
+        point_data, cell_data, field_data = _read_data(fields)
 
     # Points
     pts_dataset = mesh["NOE"]["COO"]
@@ -73,8 +73,8 @@ def read(filename):
 
     # Cells
     cells = {}
-    mai = mesh["MAI"]
-    for med_cell_type, med_cell_type_group in mai.items():
+    med_cells = mesh["MAI"]
+    for med_cell_type, med_cell_type_group in med_cells.items():
         cell_type = med_to_meshio_type[med_cell_type]
         cells[cell_type] = (
             med_cell_type_group["NOD"][()].reshape(num_nodes_per_cell[cell_type], -1).T
@@ -102,22 +102,22 @@ def read(filename):
     return mesh
 
 
-def _read_data(cha):
+def _read_data(fields):
     point_data = {}
     cell_data = {}
     field_data = {}
-    for name, data in cha.items():
-        ts = sorted(data.keys())  # associated time-steps
-        if len(ts) == 1:  # single time-step
+    for name, data in fields.items():
+        time_step = sorted(data.keys())  # associated time-steps
+        if len(time_step) == 1:  # single time-step
             names = [name]  # do not change field name
         else:  # many time-steps
-            names = [None] * len(ts)
-            for i, key in enumerate(ts):
+            names = [None] * len(time_step)
+            for i, key in enumerate(time_step):
                 t = data[key].attrs["PDT"]  # current time
                 names[i] = name + "[{:d}] - {:g}".format(i, t)
 
         # MED field can contain multiple types of data
-        for i, key in enumerate(ts):
+        for i, key in enumerate(time_step):
             datum = data[key]  # at a particular time step
             name = names[i]
             for supp in datum:
@@ -131,8 +131,8 @@ def _read_data(cha):
 
 def _read_nodal_data(data):
     nodal_dataset = data["NOE"][data["NOE"].attrs["PFL"]]
-    nbr = nodal_dataset.attrs["NBR"]
-    values = nodal_dataset["CO"][()].reshape(-1, nbr).T
+    n_components = nodal_dataset.attrs["NBR"]
+    values = nodal_dataset["CO"][()].reshape(-1, n_components).T
     if values.shape[1] == 1:  # cut off for scalars
         values = values[:, 0]
     return values
@@ -141,18 +141,18 @@ def _read_nodal_data(data):
 def _read_cell_data(cell_data, name, supp, data):
     med_type = supp.partition(".")[2]
     cell_dataset = data[supp][data[supp].attrs["PFL"]]
-    nbr = cell_dataset.attrs["NBR"]  # number of cells
-    nga = cell_dataset.attrs["NGA"]  # number of Gauss points
+    n_components = cell_dataset.attrs["NBR"]
+    n_gauss_points = cell_dataset.attrs["NGA"]
 
     # Only 1 Gauss/elemental nodal point per cell
-    if nga == 1:
-        values = cell_dataset["CO"][()].reshape(-1, nbr).T
+    if n_gauss_points == 1:
+        values = cell_dataset["CO"][()].reshape(-1, n_components).T
         if values.shape[1] == 1:  # cut off for scalars
             values = values[:, 0]
     # Multiple Gauss/elemental nodal points per cell
-    # In general at each cell the value shape will be (nco, nga)
+    # In general at each cell the value shape will be (n_components, n_gauss_points)
     else:
-        values = cell_dataset["CO"][()].reshape(-1, nbr, nga)
+        values = cell_dataset["CO"][()].reshape(-1, n_components, n_gauss_points)
         values = numpy.swapaxes(values, 0, 1)
 
     try:  # cell type already exists
@@ -166,13 +166,13 @@ def _read_cell_data(cell_data, name, supp, data):
 def _read_families(fas_data):
     families = {}
     for _, node_set in fas_data.items():
-        num = node_set.attrs["NUM"]  # unique set id
-        nbr = node_set["GRO"].attrs["NBR"]  # number of subsets
-        nom_dataset = node_set["GRO"]["NOM"][()]  # (nbr, 80) of int8
-        nom = [None] * nbr
-        for i in range(nbr):
-            nom[i] = "".join([chr(x) for x in nom_dataset[i] if x != 0])
-        families[num] = nom
+        set_id = node_set.attrs["NUM"]  # unique set id
+        n_subsets = node_set["GRO"].attrs["NBR"]  # number of subsets
+        nom_dataset = node_set["GRO"]["NOM"][()]  # (n_subsets, 80) of int8
+        name = [None] * n_subsets
+        for i in range(n_subsets):
+            name[i] = "".join([chr(x) for x in nom_dataset[i] if x != 0])
+        families[set_id] = name
     return families
 
 
@@ -189,9 +189,9 @@ def write(filename, mesh, add_global_ids=True):
     info.attrs.create("REL", 0)
 
     # Meshes
-    ens_maa = f.create_group("ENS_MAA")
+    mesh_ensemble = f.create_group("ENS_MAA")
     mesh_name = "mesh"
-    med_mesh = ens_maa.create_group(mesh_name)
+    med_mesh = mesh_ensemble.create_group(mesh_name)
     med_mesh.attrs.create("DIM", mesh.points.shape[1])  # mesh dimension
     med_mesh.attrs.create("ESP", mesh.points.shape[1])  # spatial dimension
     med_mesh.attrs.create("REP", 0)  # cartesian coordinate system (repère in french)
@@ -199,88 +199,88 @@ def write(filename, mesh, add_global_ids=True):
     med_mesh.attrs.create("UNI", b"")  # spatial unit
     med_mesh.attrs.create("SRT", 1)  # sorting type MED_SORT_ITDT
     med_mesh.attrs.create(
-        "NOM", _comp_nom(mesh.points.shape[1]).encode("ascii")
+        "NOM", _component_names(mesh.points.shape[1]).encode("ascii")
     )  # component names
     med_mesh.attrs.create("DES", b"Mesh created with meshio")
     med_mesh.attrs.create("TYP", 0)  # mesh type (MED_NON_STRUCTURE)
 
     # Time-step
     step = "-0000000000000000001-0000000000000000001"  # NDT NOR
-    ts = med_mesh.create_group(step)
-    ts.attrs.create("CGT", 1)
-    ts.attrs.create("NDT", -1)  # no time step (-1)
-    ts.attrs.create("NOR", -1)  # no iteration step (-1)
-    ts.attrs.create("PDT", -1.0)  # current time
+    time_step = med_mesh.create_group(step)
+    time_step.attrs.create("CGT", 1)
+    time_step.attrs.create("NDT", -1)  # no time step (-1)
+    time_step.attrs.create("NOR", -1)  # no iteration step (-1)
+    time_step.attrs.create("PDT", -1.0)  # current time
 
     # Points
-    noe_group = ts.create_group("NOE")
-    noe_group.attrs.create("CGT", 1)
-    noe_group.attrs.create("CGS", 1)
-    pfl = "MED_NO_PROFILE_INTERNAL"
-    noe_group.attrs.create("PFL", pfl.encode("ascii"))
-    coo = noe_group.create_dataset("COO", data=mesh.points.T.flatten())
+    nodes_group = time_step.create_group("NOE")
+    nodes_group.attrs.create("CGT", 1)
+    nodes_group.attrs.create("CGS", 1)
+    profile = "MED_NO_PROFILE_INTERNAL"
+    nodes_group.attrs.create("PFL", profile.encode("ascii"))
+    coo = nodes_group.create_dataset("COO", data=mesh.points.T.flatten())
     coo.attrs.create("CGT", 1)
     coo.attrs.create("NBR", len(mesh.points))
 
     # Point tags
     if "point_tags" in mesh.point_data:  # works only for med -> med
-        fam = noe_group.create_dataset("FAM", data=mesh.point_data["point_tags"])
-        fam.attrs.create("CGT", 1)
-        fam.attrs.create("NBR", len(mesh.points))
+        family = nodes_group.create_dataset("FAM", data=mesh.point_data["point_tags"])
+        family.attrs.create("CGT", 1)
+        family.attrs.create("NBR", len(mesh.points))
 
     # Cells (mailles in french)
-    mai_group = ts.create_group("MAI")
-    mai_group.attrs.create("CGT", 1)
+    cells_group = time_step.create_group("MAI")
+    cells_group.attrs.create("CGT", 1)
     for cell_type, cells in mesh.cells.items():
         med_type = meshio_to_med_type[cell_type]
-        mai = mai_group.create_group(med_type)
-        mai.attrs.create("CGT", 1)
-        mai.attrs.create("CGS", 1)
-        mai.attrs.create("PFL", pfl.encode("ascii"))
-        nod = mai.create_dataset("NOD", data=cells.T.flatten() + 1)
+        med_cells = cells_group.create_group(med_type)
+        med_cells.attrs.create("CGT", 1)
+        med_cells.attrs.create("CGS", 1)
+        med_cells.attrs.create("PFL", profile.encode("ascii"))
+        nod = med_cells.create_dataset("NOD", data=cells.T.flatten() + 1)
         nod.attrs.create("CGT", 1)
         nod.attrs.create("NBR", len(cells))
 
         # Cell tags
         if cell_type in mesh.cell_data:
             if "cell_tags" in mesh.cell_data[cell_type]:  # works only for med -> med
-                fam = mai.create_dataset(
+                family = med_cells.create_dataset(
                     "FAM", data=mesh.cell_data[cell_type]["cell_tags"]
                 )
-                fam.attrs.create("CGT", 1)
-                fam.attrs.create("NBR", len(cells))
+                family.attrs.create("CGT", 1)
+                family.attrs.create("NBR", len(cells))
 
     # Information about point and cell sets (familles in french)
     fas = f.create_group("FAS")
-    fm = fas.create_group(mesh_name)
-    fz = fm.create_group("FAMILLE_ZERO")  # must be defined in any case
-    fz.attrs.create("NUM", 0)
+    families = fas.create_group(mesh_name)
+    family_zero = families.create_group("FAMILLE_ZERO")  # must be defined in any case
+    family_zero.attrs.create("NUM", 0)
 
     # For point tags
     try:
         if len(mesh.point_tags) > 0:
-            noeud = fm.create_group("NOEUD")
-            _write_families(noeud, mesh.point_tags)
+            node = families.create_group("NOEUD")
+            _write_families(node, mesh.point_tags)
     except AttributeError:
         pass
 
     # For cell tags
     try:
         if len(mesh.cell_tags) > 0:
-            eleme = fm.create_group("ELEME")
-            _write_families(eleme, mesh.cell_tags)
+            element = families.create_group("ELEME")
+            _write_families(element, mesh.cell_tags)
     except AttributeError:
         pass
 
     # Write nodal/cell data
-    cha = f.create_group("CHA")
+    fields = f.create_group("CHA")
 
     # Nodal data
     for name, data in mesh.point_data.items():
         if name == "point_tags":  # ignore point_tags already written under FAS
             continue
         supp = "NOEU"  # nodal data
-        _write_data(cha, mesh_name, pfl, name, supp, data)
+        _write_data(fields, mesh_name, profile, name, supp, data)
 
     # Cell data
     # Only support writing ELEM fields with only 1 Gauss point per cell
@@ -291,8 +291,8 @@ def write(filename, mesh, add_global_ids=True):
                 continue
 
             # Determine the nature of the cell data
-            # Either data.shape = (nbr, ) or (nbr, nco) -> ELEM
-            # or data.shape = (nbr, nco, nga) -> ELNO or ELGA
+            # Either data.shape = (n_cells, ) or (n_cells, n_components) -> ELEM
+            # or data.shape = (n_cells, n_components, n_gauss_points) -> ELNO or ELGA
             med_type = meshio_to_med_type[cell_type]
             nn = int(med_type[-1])  # number of nodes per cell
             if data.ndim <= 2:
@@ -301,94 +301,94 @@ def write(filename, mesh, add_global_ids=True):
                 supp = "ELNO"
             else:  # general ELGA data defined at unknown Gauss points
                 supp = "ELGA"
-            _write_data(cha, mesh_name, pfl, name, supp, data, med_type)
+            _write_data(fields, mesh_name, profile, name, supp, data, med_type)
 
     return
 
 
-def _write_data(cha, mesh_name, pfl, name, supp, data, med_type=None):
+def _write_data(fields, mesh_name, profile, name, supp, data, med_type):
     # Skip for general ELGA fields defined at unknown Gauss points
     if supp == "ELGA":
         return
 
     # Field
     try:  # a same MED field may contain fields of different natures
-        field = cha.create_group(name)
+        field = fields.create_group(name)
         field.attrs.create("MAI", mesh_name.encode("ascii"))
         field.attrs.create("TYP", 6)  # MED_FLOAT64
         field.attrs.create("UNI", b"")  # physical unit
         field.attrs.create("UNT", b"")  # time unit
-        nco = 1 if data.ndim == 1 else data.shape[1]
-        field.attrs.create("NCO", nco)  # number of components
-        field.attrs.create("NOM", _comp_nom(nco).encode("ascii"))
+        n_components = 1 if data.ndim == 1 else data.shape[1]
+        field.attrs.create("NCO", n_components)  # number of components
+        field.attrs.create("NOM", _component_names(n_components).encode("ascii"))
 
         # Time-step
         step = "0000000000000000000100000000000000000001"
-        ts = field.create_group(step)
-        ts.attrs.create("NDT", 1)  # time step 1
-        ts.attrs.create("NOR", 1)  # iteration step 1
-        ts.attrs.create("PDT", 0.0)  # current time
-        ts.attrs.create("RDT", -1)  # NDT of the mesh
-        ts.attrs.create("ROR", -1)  # NOR of the mesh
+        time_step = field.create_group(step)
+        time_step.attrs.create("NDT", 1)  # time step 1
+        time_step.attrs.create("NOR", 1)  # iteration step 1
+        time_step.attrs.create("PDT", 0.0)  # current time
+        time_step.attrs.create("RDT", -1)  # NDT of the mesh
+        time_step.attrs.create("ROR", -1)  # NOR of the mesh
 
     except ValueError:  # name already exists
-        field = cha[name]
+        field = fields[name]
         ts_name = list(field.keys())[-1]
-        ts = field[ts_name]
+        time_step = field[ts_name]
 
     # Field information
     if supp == "NOEU":
-        typ = ts.create_group("NOE")
+        typ = time_step.create_group("NOE")
     elif supp == "ELNO":
-        typ = ts.create_group("NOE." + med_type)
+        typ = time_step.create_group("NOE." + med_type)
     else:  # 'ELEM' with only 1 Gauss points!
-        typ = ts.create_group("MAI." + med_type)
+        typ = time_step.create_group("MAI." + med_type)
 
     typ.attrs.create("GAU", b"")  # no associated Gauss points
-    typ.attrs.create("PFL", pfl.encode("ascii"))
-    pfl = typ.create_group(pfl)
-    pfl.attrs.create("NBR", len(data))  # number of points
+    typ.attrs.create("PFL", profile.encode("ascii"))
+    profile = typ.create_group(profile)
+    profile.attrs.create("NBR", len(data))  # number of points
     if supp == "ELNO":
-        pfl.attrs.create("NGA", data.shape[2])
+        profile.attrs.create("NGA", data.shape[2])
     else:
-        pfl.attrs.create("NGA", 1)
-    pfl.attrs.create("GAU", b"")
+        profile.attrs.create("NGA", 1)
+    profile.attrs.create("GAU", b"")
 
     # Data
     if supp == "NOEU" or supp == "ELEM":
-        pfl.create_dataset("CO", data=data.T.flatten())
+        profile.create_dataset("CO", data=data.T.flatten())
     else:  # ELNO fields
         data = numpy.swapaxes(data, 0, 1)
-        pfl.create_dataset("CO", data=data.flatten())
+        profile.create_dataset("CO", data=data.flatten())
 
 
-def _comp_nom(nco):
+def _component_names(n_components):
     """
     To be correctly read in a MED viewer, each component must be a
     string of width 16. Since we do not know the physical nature of
     the data, we just use V1, V2, ...
     """
-    return "".join(["V%-15d" % (i + 1) for i in range(nco)])
+    return "".join(["V%-15d" % (i + 1) for i in range(n_components)])
 
 
-def _family_name(num, nom):
+def _family_name(set_id, name):
     """
     Return the FAM object name corresponding to
     the unique set id and a list of subset names
     """
-    return "FAM" + "_" + str(num) + "_" + "_".join(nom)
+    return "FAM" + "_" + str(set_id) + "_" + "_".join(name)
 
 
 def _write_families(fm_group, tags):
     """
     Write point/cell tag information under FAS/[mesh_name]
     """
-    for num, nom in tags.items():
-        fam = fm_group.create_group(_family_name(num, nom))
-        fam.attrs.create("NUM", num)
-        gro = fam.create_group("GRO")
-        gro.attrs.create("NBR", len(nom))  # number of subsets
-        dataset = gro.create_dataset("NOM", (len(nom),), dtype="80int8")
-        for i in range(len(nom)):
-            nom_80 = nom[i] + "\x00" * (80 - len(nom[i]))  # make nom 80 characters
-            dataset[i] = [ord(x) for x in nom_80]
+    for set_id, name in tags.items():
+        family = fm_group.create_group(_family_name(set_id, name))
+        family.attrs.create("NUM", set_id)
+        group = family.create_group("GRO")
+        group.attrs.create("NBR", len(name))  # number of subsets
+        dataset = group.create_dataset("NOM", (len(name),), dtype="80int8")
+        for i in range(len(name)):
+            name_80 = name[i] + "\x00" * (80 - len(name[i]))  # make name 80 characters
+            dataset[i] = [ord(x) for x in name_80]

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -50,9 +50,10 @@ def read(filename):
     # Read nodal and cell data if they exist
     try:
         cha = f["CHA"]  # champs (fields) in french
-        point_data, cell_data, field_data = _read_data(cha)
     except KeyError:
         point_data, cell_data, field_data = {}, {}, {}
+    else:
+        point_data, cell_data, field_data = _read_data(cha)
 
     # Points
     pts_dataset = mesh["NOE"]["COO"]

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -62,7 +62,7 @@ def read(filename):
     # Point tags
     if "FAM" in mesh["NOE"]:
         tags = mesh["NOE"]["FAM"][()]
-        point_data["tags"] = tags  # this may replace previous "tags"
+        point_data["point_tags"] = tags  # replacing previous "point_tags"
 
     # Information for point tags
     point_tags = {}
@@ -83,22 +83,19 @@ def read(filename):
             tags = med_cell_type_group["FAM"][()]
             if cell_type not in cell_data:
                 cell_data[cell_type] = {}
-            cell_data[cell_type]["tags"] = tags
+            cell_data[cell_type]["cell_tags"] = tags  # replacing previous "cell_tags"
 
     # Information for cell tags
     cell_tags = {}
     if "ELEME" in fas:
         cell_tags = _read_families(fas["ELEME"])
 
-    # Merge point_tags and cell_tags, ensure first set id's are unique
-    assert len(set(point_tags.keys()).intersection(cell_tags.keys())) == 0
-    tags = point_tags.copy()  # works also for dying Python 2
-    tags.update(cell_tags)
-
+    # Construct the mesh object
     mesh = Mesh(
         points, cells, point_data=point_data, cell_data=cell_data, field_data=field_data
     )
-    mesh.tags = tags
+    mesh.point_tags = point_tags
+    mesh.cell_tags = cell_tags
     return mesh
 
 

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -305,7 +305,7 @@ def write(filename, mesh, add_global_ids=True):
     return
 
 
-def _write_data(fields, mesh_name, profile, name, supp, data, med_type):
+def _write_data(fields, mesh_name, profile, name, supp, data, med_type=None):
     # Skip for general ELGA fields defined at unknown Gauss points
     if supp == "ELGA":
         return

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -65,6 +65,7 @@ def read(filename):
         point_data["point_function"] = tags
 
     # Point sets
+    point_tags = None
     fas = f["FAS"][mesh_name]
     if "NOEUD" in fas:
         point_tags = _read_families(fas["NOEUD"])
@@ -85,6 +86,7 @@ def read(filename):
             cell_data[cell_type]["cell_function"] = tags
 
     # Cell sets
+    cell_tags = None
     if "ELEME" in fas:
         cell_tags = _read_families(fas["ELEME"])
 

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -271,18 +271,14 @@ def write(filename, mesh, add_global_ids=True):
     except AttributeError:
         pass
 
-    # Ignore point_tags and cell_tags that are already
-    # written under FAS
-    mesh.point_data.pop("point_tags", None)
-    for cell_type in mesh.cell_data:
-        mesh.cell_data[cell_type].pop("cell_tags", None)
-
     # Write nodal/cell data
     if mesh.point_data or mesh.cell_data:
         cha = f.create_group("CHA")
 
         # Nodal data
         for name, data in mesh.point_data.items():
+            if name == "point_tags":  # ignore point_tags already written under FAS
+                continue
             supp = "NOEU"  # nodal data
             _write_data(cha, mesh_name, pfl, name, supp, data)
 
@@ -291,6 +287,8 @@ def write(filename, mesh, add_global_ids=True):
         # Or ELNO (DG) fields defined at every node per cell
         for cell_type, d in mesh.cell_data.items():
             for name, data in d.items():
+                if name == "cell_tags":  # ignore cell_tags already written under FAS
+                    continue
 
                 # Determine the nature of the cell data
                 # Either data.shape = (nbr, ) or (nbr, nco) -> ELEM

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -241,10 +241,13 @@ def write(filename, mesh, add_global_ids=True):
         nod.attrs.create("NBR", len(cells))
 
         # Cell tags
-        if "cell_tags" in mesh.cell_data[cell_type]:  # works only for med -> med
-            fam = mai.create_dataset("FAM", data=mesh.cell_data[cell_type]["cell_tags"])
-            fam.attrs.create("CGT", 1)
-            fam.attrs.create("NBR", len(cells))
+        if cell_type in mesh.cell_data:
+            if "cell_tags" in mesh.cell_data[cell_type]:  # works only for med -> med
+                fam = mai.create_dataset(
+                    "FAM", data=mesh.cell_data[cell_type]["cell_tags"]
+                )
+                fam.attrs.create("CGT", 1)
+                fam.attrs.create("NBR", len(cells))
 
     # Information about point and cell sets (familles in french)
     fas = f.create_group("FAS")

--- a/meshio/med_io.py
+++ b/meshio/med_io.py
@@ -294,10 +294,9 @@ def write(filename, mesh, add_global_ids=True):
             # Either data.shape = (n_cells, ) or (n_cells, n_components) -> ELEM
             # or data.shape = (n_cells, n_components, n_gauss_points) -> ELNO or ELGA
             med_type = meshio_to_med_type[cell_type]
-            nn = int(med_type[-1])  # number of nodes per cell
             if data.ndim <= 2:
                 supp = "ELEM"
-            elif data.shape[2] == nn:
+            elif data.shape[2] == num_nodes_per_cell[cell_type]:
                 supp = "ELNO"
             else:  # general ELGA data defined at unknown Gauss points
                 supp = "ELGA"

--- a/test/test_med.py
+++ b/test/test_med.py
@@ -12,10 +12,14 @@ h5py = pytest.importorskip("h5py")
 @pytest.mark.parametrize(
     "mesh",
     [
-        helpers.tri_mesh,
         helpers.tri_mesh_2d,
+        helpers.tri_mesh,
+        helpers.triangle6_mesh,
         helpers.quad_mesh,
+        helpers.quad8_mesh,
+        helpers.tri_quad_mesh,
         helpers.tet_mesh,
+        helpers.tet10_mesh,
         helpers.hex_mesh,
         helpers.add_point_data(helpers.tri_mesh, 1),
         helpers.add_point_data(helpers.tri_mesh, 2),

--- a/test/test_med.py
+++ b/test/test_med.py
@@ -36,3 +36,33 @@ def test_generic_io():
     # With additional, insignificant suffix:
     helpers.generic_io("test.0.med")
     return
+
+
+@pytest.mark.parametrize(
+    "filename, md5, ref_sum_points, ref_num_cells, ref_sum_point_tags, ref_sum_cell_tags",
+    [
+        (
+            "med/cylinder.med",
+            "e36b365542c72ef470b83fc21f4dad58",
+            16.53169892762988,
+            {"pyramid": 18, "quad": 18, "line": 17, "tetra": 63, "triangle": 4},
+            52,
+            {"pyramid": -116, "quad": -75, "line": -48, "tetra": -24, "triangle": -30},
+        )
+    ],
+)
+def test_reference_file(
+    filename, md5, ref_sum_points, ref_num_cells, ref_sum_point_tags, ref_sum_cell_tags
+):
+    filename = helpers.download(filename, md5)
+
+    mesh = meshio.read(filename)
+    tol = 1.0e-2
+    s = mesh.points.sum()
+    assert abs(s - ref_sum_points) < tol * ref_sum_points
+    assert {k: len(v) for k, v in mesh.cells.items()} == ref_num_cells
+    assert mesh.point_data["point_tags"].sum() == ref_sum_point_tags
+    assert {
+        k: v["cell_tags"].sum() for k, v in mesh.cell_data.items()
+    } == ref_sum_cell_tags
+    helpers.write_read(meshio.med_io.write, meshio.med_io.read, mesh, 1.0e-15)


### PR DESCRIPTION
Based on #350, an attempt to read and write point/cell sets in a MED file.

Some characteristics of sets in a MED file are described in https://github.com/nschloe/meshio/issues/347#issuecomment-474247403, https://github.com/nschloe/meshio/issues/347#issuecomment-474251078 and https://github.com/nschloe/meshio/issues/290#issuecomment-474999314.

The current implementation will additionally provide if they are defined in the mesh
- a new `point_data` called `point_tags`, that assigns a unique node set id (positive integers, defined by MED) to each node
- a new `cell_data` called `cell_tags`, that assigns a unique element set id (negative integers, defined by MED) to each element

Since currently with gmsh you have `gmsh:physical`, so reading a MSH file with tags and then writing it to MED loses tags information, and vice versa. Maybe we can rename it also to `cell_tags`? We need to inform users by updating the change log.

Reading the example [Cylinder.zip](https://github.com/nschloe/meshio/files/2982723/Cylinder.zip), and then exporting to VTU gives under ParaView the expected behavior (here `cell_tags = -6` corresponds to the `Top circle` edge element sets).

![](https://user-images.githubusercontent.com/4027283/54751273-b568aa80-4bda-11e9-993a-928ed2b0ddb7.png)

The information about these `tags` is stored in `mesh.point_tags` and `mesh.cell_tags`: the unique set id → list of set name(s) defined in the mesh. Additionally, intersections of sets internally created by MED are decomposed in the list of set name(s).

The difference between gmsh `mesh.field_data` and `mesh.point/cell_tags` being that
1. Manifold dimension of sets is unavailable
2. The key of the dictionary is the unique set id defined by MED, and not the set name. In MED we can give the same name to different sets corresponding to different manifold dimensions (so `Top` can be used to group all 2d elements on the top, and all 3d elements sharing nodes on the top), internally MED will just assign another unique set id.
3. Allowing overlapping sets, by using a list of subset names for each set id.

In this example we have
``` python
mesh.point_tags =
{2: ['Side'],
 3: ['Side', 'Top'],
 4: ['Top']}

mesh.cell_tags =
{-6: ['Top circle'],
 -7: ['Top', 'Top and down'],
 -8: ['Top and down'],
 -9: ['A', 'B'],
 -10: ['B'],
 -11: ['A', 'B', 'C'],
 -12: ['B', 'C'],
 -13: ['C']}
```

So for node sets,
- `Side` set defined by the user is in fact obtained by combining nodes from 2 and 3
- `Top` can be obtained by combining 3 and 4

For element sets,
- `A` can be obtained by grouping elements tagged with -9, -11
- `B`, with -9, -10, -11, -12
- `C`, with -11, -13

Note that with MED, point sets are internally tagged with a positive number, while cell sets with a negative number.

Another important information concerning writing a mesh to MED. If the mesh contains `point_tags` and `cell_tags` in the `point_data` and `cell_data`, then they are interpreted as node/elements tags (sets, groups, ...) and not normal data. They will be written under `FAS` of MED and not under `CHA` where we put normal point/cell fields.

The reason is that if initially we have a mesh with no (other) fields but only tags `point_tags` and `cell_tags`, we don't want a MED file with both tags under `FAS` and also represented by two additional normal fields.

PS: the tags under `FAS` can be well interpreted by salome, both under the mesh module where user-defined (possibly overlapping) sets can be seen, but also under ParaVis (ParaView + MED support), where these two tags are named `FamilyidNode` and `FamilyIdCell`.

![](https://user-images.githubusercontent.com/4027283/54817657-c0cddb80-4c97-11e9-98ee-c44f7a5cf522.png)
