### PR TITLE
WIP: update function calls to match syntax of pygmsh-v5.0.0 and optimesh-v0.4.4

### DIFF
--- a/logo/logo.py
+++ b/logo/logo.py
@@ -19,8 +19,9 @@ def create_logo():
 
     geom.boolean_difference([container], [letter_i, i_dot, letter_o])
 
-    X, cells, _, _, _ = pygmsh.generate_mesh(geom)
-    X, cells = optimesh.lloyd(X, cells["triangle"], 1.0e-3, 1000)
+    mesh = pygmsh.generate_mesh(geom)
+    X, cells = mesh.points, mesh.cells
+    X, cells = optimesh.cvt.lloyd.quasi_newton_uniform_lloyd(X, cells["triangle"], 1.0e-3, 1000)
     return X, cells
 
 


### PR DESCRIPTION
In the latest version of `pygmsh`, call to `pygmsh.generate_mesh()` returns a `Mesh` object. Also, in the latest version of `optimesh`, `lloyd` has been moved to directory `cvt`. This pull request is to address these issues.

Another place where the code breaks due to old `pygmsh` syntax is in the test file `performance.py`. But, even after correcting the syntax the code results in key error for `key: "vertex"`