### PR TITLE
Add instruction for pulling in all dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ pip install -U meshio
 ```
 to install or upgrade.
 
+Additional dependencies (`netcdf4`, `h5py` and `lxml`) are required for some of the output formats and can be pulled in by:
+
+```
+pip install -U meshio[all]
+```
 
 ### Testing
 


### PR DESCRIPTION
The README currently advises to install using plain `pip install meshio` which leads to issues like https://github.com/nschloe/meshio/issues/264. Add instruction to use `meshio[all]` if desired.