### PR TITLE
Fix for 2D meshes converted with gmsh

### DIFF
--- a/meshio/msh_io/common.py
+++ b/meshio/msh_io/common.py
@@ -212,3 +212,13 @@ def _write_data(fh, tag, name, data, write_binary):
 
     fh.write("$End{}\n".format(tag).encode("utf-8"))
     return
+
+
+def check_whether_2D(points):
+    # determine, whether 2D data
+    # compare to z component of first element. if z is always the same, the mesh is 2D
+    reference = points[0][2]
+    if all(point == reference for point in points[:, 2:]):
+        # make it 2D
+        points = points[:, :2]
+    return points

--- a/meshio/msh_io/msh2.py
+++ b/meshio/msh_io/msh2.py
@@ -20,6 +20,7 @@ from .common import (
     _write_physical_names,
     _read_data,
     _write_data,
+    check_whether_2D
 )
 
 c_int = numpy.dtype("i")
@@ -105,6 +106,7 @@ def _read_nodes(f, is_ascii, data_size):
 
     line = f.readline().decode("utf-8")
     assert line.strip() == "$EndNodes"
+    points = check_whether_2D(points)
     return points
 
 

--- a/meshio/msh_io/msh4_0.py
+++ b/meshio/msh_io/msh4_0.py
@@ -21,6 +21,7 @@ from .common import (
     _write_physical_names,
     _read_data,
     _write_data,
+    check_whether_2D
 )
 
 c_int = numpy.dtype("i")
@@ -155,6 +156,8 @@ def _read_nodes(f, is_ascii, data_size):
 
     line = f.readline().decode("utf-8")
     assert line.strip() == "$EndNodes"
+    points = check_whether_2D(points)
+
 
     return points, tags
 

--- a/meshio/msh_io/msh4_0.py
+++ b/meshio/msh_io/msh4_0.py
@@ -158,7 +158,6 @@ def _read_nodes(f, is_ascii, data_size):
     assert line.strip() == "$EndNodes"
     points = check_whether_2D(points)
 
-
     return points, tags
 
 

--- a/meshio/msh_io/msh4_1.py
+++ b/meshio/msh_io/msh4_1.py
@@ -22,6 +22,7 @@ from .common import (
     # _write_physical_names,
     # _write_data,
     _read_data,
+    check_whether_2D
 )
 from .msh2 import write as write2  # revert where necessary; TODO: drop this
 
@@ -155,7 +156,7 @@ def _read_nodes(f, is_ascii, data_size):
 
     line = f.readline().decode("utf-8")
     assert line.strip() == "$EndNodes"
-
+    points = check_whether_2D(points)
     return points, tags
 
 


### PR DESCRIPTION
When creating a mesh for instance in SALOME and exporting it in MED format, it can be converted to msh format by using gmsh. Then all the physical and geometrical tags are kept.
If the geometry is a 2D geometry, there will be still 3 coordinates (with z being equal to 0). That makes meshio think, the mesh is 3D. I do not know whether this is also the case with STEP geometries meshed in gmsh or native gmsh geometries and meshes, but it could well be.

With the fix here, this is circumvented and the points are returned in the right format, such that the information is also correct in other export formats (e.g. xmdf).
I use FEniCS with xdmf and there without the fix the workflow I prefer (CAD + mesh: SALOME, conversion MED to msh: gmsh, conversion to xdmf: meshio) would not work.