### PR TITLE
read MSH 4.1 node tags and populate points accordingly

### DIFF
--- a/meshio/msh_io/msh4_1.py
+++ b/meshio/msh_io/msh4_1.py
@@ -128,7 +128,6 @@ def _read_nodes(f, is_ascii, data_size):
     num_entity_blocks, total_num_nodes, min_node_tag, max_node_tag = fromfile(
         f, c_size_t, 4
     )
-    is_dense = min_node_tag == 1 and max_node_tag == total_num_nodes
 
     points = numpy.empty((total_num_nodes, 3), dtype=float)
     tags = numpy.empty(total_num_nodes, dtype=int)

--- a/meshio/msh_io/msh4_1.py
+++ b/meshio/msh_io/msh4_1.py
@@ -131,7 +131,7 @@ def _read_nodes(f, is_ascii, data_size):
     is_dense = min_node_tag == 1 and max_node_tag == total_num_nodes
 
     points = numpy.empty((total_num_nodes, 3), dtype=float)
-    tags = (numpy.arange if is_dense else numpy.empty)(total_num_nodes, dtype=int)
+    tags = numpy.empty(total_num_nodes, dtype=int)
 
     idx = 0
     for k in range(num_entity_blocks):
@@ -141,11 +141,8 @@ def _read_nodes(f, is_ascii, data_size):
         num_nodes = int(fromfile(f, c_size_t, 1)[0])
         ixx = slice(idx, idx + num_nodes)
 
-        if is_dense:
-            fromfile(f, c_size_t, num_nodes)
-        else:
-            tags[ixx] = fromfile(f, c_size_t, num_nodes) - 1
-        points[ixx] = fromfile(f, c_double, num_nodes * 3).reshape((num_nodes, 3))
+        tags[ixx] = fromfile(f, c_size_t, num_nodes) - 1
+        points[tags[ixx]] = fromfile(f, c_double, num_nodes * 3).reshape((num_nodes, 3))
         idx += num_nodes
 
     if not is_ascii:

--- a/meshio/msh_io/msh4_1.py
+++ b/meshio/msh_io/msh4_1.py
@@ -148,7 +148,7 @@ def _read_nodes(f, is_ascii, data_size):
         # Following https://github.com/nschloe/meshio/issues/388, we
         # read the tags and populate the points array accordingly,
         # thereby preserving the order of indices of nodes/points.
-        
+
         ixx = slice(idx, idx + num_nodes)
         tags[ixx] = fromfile(f, c_size_t, num_nodes) - 1
 

--- a/meshio/msh_io/msh4_1.py
+++ b/meshio/msh_io/msh4_1.py
@@ -138,9 +138,21 @@ def _read_nodes(f, is_ascii, data_size):
         _, __, parametric = fromfile(f, c_int, 3)
         assert parametric == 0, "parametric nodes not implemented"
         num_nodes = int(fromfile(f, c_size_t, 1)[0])
-        ixx = slice(idx, idx + num_nodes)
 
+        # nodeTag(size_t) (* numNodes)
+
+        # Note that 'tags can be "sparse", i.e., do not have to
+        # constitute a continuous list of numbers (the format even
+        # allows them to not be ordered)'
+        # <http://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format>.
+        # Following https://github.com/nschloe/meshio/issues/388, we
+        # read the tags and populate the points array accordingly,
+        # thereby preserving the order of indices of nodes/points.
+        
+        ixx = slice(idx, idx + num_nodes)
         tags[ixx] = fromfile(f, c_size_t, num_nodes) - 1
+
+        # x(double) y(double) z(double) (* numNodes)
         points[tags[ixx]] = fromfile(f, c_double, num_nodes * 3).reshape((num_nodes, 3))
         idx += num_nodes
 


### PR DESCRIPTION
Previously, the node tags in MSH 4.1 were just discarded, on the assumption, or rather following the [MSH file format](http://gmsh.info/dev/doc/texinfo/gmsh.html#MSH-file-format) specification, that

> By default, for non-partitioned, single file meshes, Gmsh will create files with a continuous ordering of node and element tags

As reported in #388, this isn't quite true, failing if in Gmsh's graphical user interface one generates a mesh and then increases its order (e.g. adding nodes on the midpoints for P2 elements): the first order nodes keep their old numbers and the new ones are given numbers in a higher range, but then they are listed in the output .msh file out of order.

The simple remedy proposed here is to read the tags and use them as indices of where to store them in the `points` array.