### PR TITLE
VTK: add ability to read structured meshes and metadata

### DIFF
--- a/meshio/vtk_io.py
+++ b/meshio/vtk_io.py
@@ -291,7 +291,6 @@ def read_buffer(f):
         ]
         points = _generate_points(axis)
         c, ct = _generate_cells(dim=dataset["DIMENSIONS"])
-        pass
     elif dataset["type"] == "RECTILINEAR_GRID":
         axis = [
             dataset["X_COORDINATES"],

--- a/meshio/vtk_io.py
+++ b/meshio/vtk_io.py
@@ -276,15 +276,15 @@ def _read_sub_section(f, info):
         if info.section[1:] == "_COORDINATES":
             info.num_points = int(info.split[1])
             data_type = info.split[2].lower()
-            info.dataset[info.section] = _read_coords(
+            d[info.section] = _read_coords(
                 f, data_type, info.is_ascii, info.num_points
             )
         else:
-            info.dataset[info.section] = list(map(int, info.split[1:]))
+            d[info.section] = list(map(int, info.split[1:]))
             assert (
-                len(info.dataset[info.section]) == 3
+                len(d[info.section]) == 3
             ), "Wrong number of info in section '{}'. Need 3, got {}.".format(
-                info.section, len(info.dataset[info.section])
+                info.section, len(d[info.section])
             )
     elif info.section == "SCALARS":
         d.update(_read_scalar_field(f, info.num_items, info.split))

--- a/meshio/vtk_io.py
+++ b/meshio/vtk_io.py
@@ -278,6 +278,15 @@ def read_buffer(f):
                 assert section == "FIELD", "Unknown section '{}'.".format(section)
                 d.update(_read_fields(f, int(split[2]), is_ascii))
 
+    points, c, ct = _check_mesh(dataset, points, c, ct)
+    cells, cell_data = translate_cells(c, ct, cell_data_raw)
+
+    return Mesh(
+        points, cells, point_data=point_data, cell_data=cell_data, field_data=field_data
+    )
+
+
+def _check_mesh(dataset, points, c, ct):
     if dataset["type"] == "UNSTRUCTURED_GRID":
         assert c is not None, "Required section CELLS not found."
         assert ct is not None, "Required section CELL_TYPES not found."
@@ -301,12 +310,7 @@ def read_buffer(f):
         c, ct = _generate_cells(dim=dataset["DIMENSIONS"])
     elif dataset["type"] == "STRUCTURED_GRID":
         c, ct = _generate_cells(dim=dataset["DIMENSIONS"])
-
-    cells, cell_data = translate_cells(c, ct, cell_data_raw)
-
-    return Mesh(
-        points, cells, point_data=point_data, cell_data=cell_data, field_data=field_data
-    )
+    return points, c, ct
 
 
 def _generate_cells(dim):

--- a/meshio/vtk_io.py
+++ b/meshio/vtk_io.py
@@ -276,9 +276,7 @@ def _read_sub_section(f, info):
         if info.section[1:] == "_COORDINATES":
             info.num_points = int(info.split[1])
             data_type = info.split[2].lower()
-            d[info.section] = _read_coords(
-                f, data_type, info.is_ascii, info.num_points
-            )
+            d[info.section] = _read_coords(f, data_type, info.is_ascii, info.num_points)
         else:
             d[info.section] = list(map(int, info.split[1:]))
             assert (

--- a/meshio/vtk_io.py
+++ b/meshio/vtk_io.py
@@ -148,7 +148,7 @@ def read(filename):
     return out
 
 
-def read_buffer(f):
+def read_buffer(f):  # noqa: C901
     # initialize output data
     points = None
     field_data = {}

--- a/meshio/vtk_io.py
+++ b/meshio/vtk_io.py
@@ -278,7 +278,10 @@ def _read_sub_section(f, info):
             data_type = info.split[2].lower()
             d[info.section] = _read_coords(f, data_type, info.is_ascii, info.num_points)
         else:
-            d[info.section] = list(map(int, info.split[1:]))
+            if info.section == "DIMENSIONS":
+                d[info.section] = list(map(int, info.split[1:]))
+            else:
+                d[info.section] = list(map(float, info.split[1:]))
             assert (
                 len(d[info.section]) == 3
             ), "Wrong number of info in section '{}'. Need 3, got {}.".format(

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -64,5 +64,24 @@ def test_reference_file(filename, md5, ref_sum, ref_num_cells, write_binary):
     return
 
 
+@pytest.mark.parametrize(
+    "filename, md5, ref_cells, ref_num_cells, ref_num_pnt",
+    [
+        ('vtk/01_image.vtk', '3981abae840ef521121bf8829252ae04', 'hexahedron', 72, 147),
+        ('vtk/02_structured.vtk', '0a958a46b7629149abb03e4af47b7d29', 'hexahedron', 72, 147),
+        ('vtk/03_rectilinear.vtk', '7b5c057940e61e88a933f7a63e99aae0', 'hexahedron', 72, 147),
+        ('vtk/04_rectilinear.vtk', 'f75ddbebb907fdd73159bfcfc46fdbd5', 'quad', 27, 40),
+        ('vtk/05_rectilinear.vtk', '9f9bbccb7d76277b457162c0a2d3f9e9', 'quad', 27, 40),
+    ],
+)
+def test_structured(filename, md5, ref_cells, ref_num_cells, ref_num_pnt):
+    filename = helpers.download(filename, md5)
+    mesh = meshio.read(filename)
+    assert len(mesh.cells) == 1
+    assert ref_cells in mesh.cells
+    assert len(mesh.cells[ref_cells]) == ref_num_cells
+    assert len(mesh.points) == ref_num_pnt
+
+
 if __name__ == "__main__":
     test(helpers.tri_mesh, write_binary=True)

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -67,6 +67,7 @@ def test_reference_file(filename, md5, ref_sum, ref_num_cells, write_binary):
 @pytest.mark.parametrize(
     "filename, md5, ref_cells, ref_num_cells, ref_num_pnt",
     [
+        ("vtk/00_image.vtk", "2c800ca9734fe92172d9693f0e58fe8f", "quad", 81, 100),
         ("vtk/01_image.vtk", "3981abae840ef521121bf8829252ae04", "hexahedron", 72, 147),
         (
             "vtk/02_structured.vtk",

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -67,11 +67,23 @@ def test_reference_file(filename, md5, ref_sum, ref_num_cells, write_binary):
 @pytest.mark.parametrize(
     "filename, md5, ref_cells, ref_num_cells, ref_num_pnt",
     [
-        ('vtk/01_image.vtk', '3981abae840ef521121bf8829252ae04', 'hexahedron', 72, 147),
-        ('vtk/02_structured.vtk', '0a958a46b7629149abb03e4af47b7d29', 'hexahedron', 72, 147),
-        ('vtk/03_rectilinear.vtk', '7b5c057940e61e88a933f7a63e99aae0', 'hexahedron', 72, 147),
-        ('vtk/04_rectilinear.vtk', 'f75ddbebb907fdd73159bfcfc46fdbd5', 'quad', 27, 40),
-        ('vtk/05_rectilinear.vtk', '9f9bbccb7d76277b457162c0a2d3f9e9', 'quad', 27, 40),
+        ("vtk/01_image.vtk", "3981abae840ef521121bf8829252ae04", "hexahedron", 72, 147),
+        (
+            "vtk/02_structured.vtk",
+            "0a958a46b7629149abb03e4af47b7d29",
+            "hexahedron",
+            72,
+            147,
+        ),
+        (
+            "vtk/03_rectilinear.vtk",
+            "7b5c057940e61e88a933f7a63e99aae0",
+            "hexahedron",
+            72,
+            147,
+        ),
+        ("vtk/04_rectilinear.vtk", "f75ddbebb907fdd73159bfcfc46fdbd5", "quad", 27, 40),
+        ("vtk/05_rectilinear.vtk", "9f9bbccb7d76277b457162c0a2d3f9e9", "quad", 27, 40),
     ],
 )
 def test_structured(filename, md5, ref_cells, ref_num_cells, ref_num_pnt):


### PR DESCRIPTION
In this pull request I add a number of structured DATASETs to the VTK-reader:

* STRUCTURED_POINTS
* STRUCTURED_GRID
* RECTILINEAR_GRID

they will be automatically converted internally to UNSTRUCTURED_GRID.

In addition, METADATA now doesn't anymore violate the reading process. Everything in METADATA will be ignored.

This tackles:
https://github.com/nschloe/meshio/issues/328
https://github.com/nschloe/meshio/issues/130
https://github.com/nschloe/meshio/issues/128

This could also be done for POLYDATA (but there, a lot of section come up: VERTICES, LINES, POLYGONS, TRIANGLE_STRIPS, that need to be converted to valid meshio cell types)

The same approach could be used for structured VTK XML files, but it get a bit more complicated and there, different file endings for every type exists (vti, vtp, vtr, vts), so the question arises if there should be one reader for each or not.