### PR TITLE
Fix issue 34, reading .msh when it contains binary sections.

### DIFF
--- a/meshio/msh_io/msh4_0.py
+++ b/meshio/msh_io/msh4_0.py
@@ -72,7 +72,14 @@ def read_buffer(f, is_ascii, data_size):
             # ```
             # skip environment
             while line != "$End" + environ:
-                line = f.readline().decode("utf-8").strip()
+                line = f.readline()
+                # Skip binary strings, but try to recognize text strings
+                # to catch the end of the environment
+                # See also https://github.com/nschloe/pygalmesh/issues/34
+                try:
+                    line = line.decode("utf-8").strip()
+                except UnicodeDecodeError:
+                    pass
 
     cell_data = cell_data_from_raw(cells, cell_data_raw)
     cell_data.update(cell_tags)

--- a/meshio/msh_io/msh4_1.py
+++ b/meshio/msh_io/msh4_1.py
@@ -79,7 +79,14 @@ def read_buffer(f, is_ascii, data_size):
             # ```
             # skip environment
             while line != "$End" + environ:
-                line = f.readline().decode("utf-8").strip()
+                line = f.readline()
+                # Skip binary strings, but try to recognize text strings
+                # to catch the end of the environment
+                # See also https://github.com/nschloe/pygalmesh/issues/34
+                try:
+                    line = line.decode("utf-8").strip()
+                except UnicodeDecodeError:
+                    pass
 
     cell_data = cell_data_from_raw(cells, cell_data_raw)
     cell_data.update(cell_tags)


### PR DESCRIPTION
Fix https://github.com/nschloe/pygalmesh/issues/34

When reading a .msh file version 4.1, when the file contains a section
in the form of binary lines (for example, $Parametrizations"), an error
occurs when reading them in utf-8 encoding.

This case is processed in this PR to fix it.
The same is probably for 4.0 MeshFromat, so it is fixed too.
Now example runs without errors^
```
import meshio
fn = 'ellipsoid.msh'
mesh = meshio.read(fn)
print(mesh)
```
Output:

```
<meshio mesh object>
  Number of points: 290
  Number of elements:
    vertex: 7
    line: 76
    triangle: 396
    tetra: 785
```


file: https://goodok.github.io/data/ellipsoid.msh

The flake8 check gave the result without errors in the style