### PR TITLE
modified _abaqus.py to support reading multiple-line cells

### DIFF
--- a/meshio/_abaqus.py
+++ b/meshio/_abaqus.py
@@ -174,15 +174,26 @@ def _read_cells(f, line0, point_gids):
     cell_type = abaqus_to_meshio_type[etype]
 
     cells = []
+    is_new_cell = True
     while True:
         last_pos = f.tell()
         line = f.readline()
         if line.startswith("*") or line == "":
             break
-        entries = [int(k) for k in filter(None, line.split(","))]
-        idx = [point_gids[k] for k in entries[1:]]
-        cells.append(idx)
+        # remove trailing newlines
+        entries = [int(k) for k in filter(None, line.rstrip().split(","))]
 
+        # check for element connectivity spanning multiple lines
+        if is_new_cell:
+            idx = [point_gids[k] for k in entries[1:]]
+        else:
+            idx.extend([point_gids[k] for k in entries]) 
+        
+        if line.rstrip().endswith(','):
+            is_new_cell = False 
+        else:
+            is_new_cell = True 
+            cells.append(idx)
     f.seek(last_pos)
     return cell_type, numpy.array(cells)
 

--- a/meshio/_abaqus.py
+++ b/meshio/_abaqus.py
@@ -187,12 +187,12 @@ def _read_cells(f, line0, point_gids):
         if is_new_cell:
             idx = [point_gids[k] for k in entries[1:]]
         else:
-            idx.extend([point_gids[k] for k in entries]) 
-        
-        if line.rstrip().endswith(','):
-            is_new_cell = False 
+            idx.extend([point_gids[k] for k in entries])
+
+        if line.rstrip().endswith(","):
+            is_new_cell = False
         else:
-            is_new_cell = True 
+            is_new_cell = True
             cells.append(idx)
     f.seek(last_pos)
     return cell_type, numpy.array(cells)

--- a/meshio/_helpers.py
+++ b/meshio/_helpers.py
@@ -182,7 +182,7 @@ def write_points_cells(
     cell_data=None,
     field_data=None,
     file_format=None,
-    **kwargs
+    **kwargs,
 ):
     mesh = Mesh(
         points, cells, point_data=point_data, cell_data=cell_data, field_data=field_data

--- a/test/test_vtu.py
+++ b/test/test_vtu.py
@@ -33,7 +33,7 @@ def test(mesh, write_binary):
             write_binary=write_binary,
             # don't use pretty xml to increase test coverage
             pretty_xml=False,
-            **kwargs
+            **kwargs,
         )
 
     # ASCII files are only meant for debugging, VTK stores only 11 digits


### PR DESCRIPTION
Patched  the `_read_cells` function in `_abaqus.py` to allow reading multiple-line connectivity for elements/cells. 