### PR TITLE
Abaqus: reconsider cells defined by multiple lines

### DIFF
--- a/meshio/_abaqus.py
+++ b/meshio/_abaqus.py
@@ -178,10 +178,9 @@ def _read_cells(f, line0, point_gids):
         if line.startswith("*") or line == "":
             break
         line = line.strip()
-        # the first item is just a running index
-        idx += [point_gids[int(k)] for k in filter(None, line.split(",")[1:])]
+        idx += [point_gids[int(k)] for k in filter(None, line.split(","))]
         if not line.endswith(","):
-            cells.append(idx)
+            cells.append(idx[1:])  # the first item is just a running index
             idx = []
     return cell_type, numpy.array(cells), line
 

--- a/test/meshes/abaqus/UUea.inp
+++ b/test/meshes/abaqus/UUea.inp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28e9a4b04b09f9abc14a4ccd5085f53640671f98a2db04565003d771b382a009
-size 7373
+oid sha256:0263bf32e6bd93bbdaf9fe0ff531aaad9ac9af8722100ef8f92813f8c2ccdb3b
+size 7338


### PR DESCRIPTION
I'm afraid 08497a6a3cfd44dc33ea63289077e0fb3142907e breaks again #409.

In case of continuation, the first chunk is part of the current cell definition.

Some continuation cases are added in the test file.