### PR TITLE
Allow reading some XDMF time-series à la FEniCS

### DIFF
--- a/meshio/_xdmf/time_series.py
+++ b/meshio/_xdmf/time_series.py
@@ -42,14 +42,6 @@ class XdmfTimeSeriesReader:
 
         grids = list(self.domain)
 
-        # find the uniform grid
-        self.mesh_grid = None
-        for g in grids:
-            if g.attrib["GridType"] == "Uniform":
-                self.mesh_grid = g
-        assert self.mesh_grid is not None, "Couldn't find the mesh grid"
-        assert self.mesh_grid.tag == "Grid"
-
         # find the collection grid
         collection_grid = None
         for g in grids:
@@ -58,11 +50,29 @@ class XdmfTimeSeriesReader:
         assert collection_grid is not None, "Couldn't find the mesh grid"
         assert collection_grid.tag == "Grid"
         assert collection_grid.attrib["CollectionType"] == "Temporal"
+
         # get the collection at once
         self.collection = list(collection_grid)
         self.num_steps = len(self.collection)
         self.cells = None
         self.hdf5_files = {}
+
+        # find the uniform grid
+        self.mesh_grid = None
+        for g in grids:
+            if g.attrib["GridType"] == "Uniform":
+                self.mesh_grid = g
+        # if not found, take the first uniform grid in the collection grid
+        if self.mesh_grid is None:
+            for g in self.collection:
+                try:
+                    if g.attrib["GridType"] == "Uniform":
+                        self.mesh_grid = g
+                        break
+                except KeyError:
+                    continue
+        assert self.mesh_grid is not None, "Couldn't find the mesh grid"
+        assert self.mesh_grid.tag == "Grid"
 
     def __enter__(self):
         return self


### PR DESCRIPTION
Currently the XDMF time-series interface accepts the following XML format, with one `Collection` grid for time-series and one `Uniform` grid for mesh
``` xml
<Xdmf Version="3.0">
  <Domain>
    <Grid Name="TimeSeries_meshio" GridType="Collection" CollectionType="Temporal">
      <Grid>
        <ns0:include xmlns:ns0="http://www.w3.org/2003/XInclude" xpointer="xpointer(//Grid[@Name=&quot;mesh&quot;]/*[self::Topology or self::Geometry])"/>
        <Time Value="1"/>
        <Attribute>...</Attribute>
      </Grid>
      <Grid>
        <ns1:include xmlns:ns1="http://www.w3.org/2003/XInclude" xpointer="xpointer(//Grid[@Name=&quot;mesh&quot;]/*[self::Topology or self::Geometry])"/>
        <Time Value="2"/>
        <Attribute>...</Attribute>
      </Grid>
    </Grid>
    <Grid Name="mesh" GridType="Uniform">
      <Geometry>...</Geometry>
      <Topology>...</Topology>
    </Grid>
  </Domain>
</Xdmf>
```

With `xdmf_file.parameters["functions_share_mesh"] = True`, FEniCS writes only one `Collection` grid. The mesh is
- either defined for each time step (a `Uniform` grid per time-step)

``` xml
<Xdmf Version="3.0">
  <Domain>
    <Grid CollectionType="Temporal" GridType="Collection" Name="TimeSeries">
      <Grid GridType="Uniform" Name="Results">
        <Time Value="1.0329"/>
        <Geometry>...</Geometry>
        <Topology>...</Topology>
        <Attribute>...</Attribute>
      </Grid>
      <Grid GridType="Uniform" Name="Results">
        <Time Value="1.0429"/>
        <Geometry>...</Geometry>
        <Topology>...</Topology>
        <Attribute>...</Attribute>
      </Grid>
    </Grid>
  </Domain>
</Xdmf>
```

- either defined at the 1st time step (only one `Uniform` grid in this collection), when one uses the `rewrite_function_mesh = False` option. See also #461.

``` xml
<?xml version="1.0"?>
<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>
<Xdmf Version="3.0" xmlns:xi="http://www.w3.org/2001/XInclude">
  <Domain>
    <Grid Name="TimeSeries" GridType="Collection" CollectionType="Temporal">
      <Grid Name="mesh" GridType="Uniform">
        <Topology>...</Topology>
        <Geometry>...</Geometry>
        <Time Value="0" />
        <Attribute>...</Attribute>
      </Grid>
      <Grid>
        <xi:include xpointer="xpointer(//Grid[@Name=&quot;TimeSeries&quot;]/Grid[1]/*[self::Topology or self::Geometry])" />
        <Time Value="1" />
        <Attribute>...</Attribute>
      </Grid>
    </Grid>
  </Domain>
</Xdmf>
```

This PR allows reading these two formats.

By default, we have `xdmf_file.parameters["functions_share_mesh"] = False`, this means if several functions are exported per time-step, then we have several `Collection` grids present in the XML file corresponding to those functions. Allowing this kind of time-series will be tackled by future PR's.