### PR TITLE
add SPHERE and CIRCLE elements

### DIFF
--- a/meshio/_exodus.py
+++ b/meshio/_exodus.py
@@ -14,6 +14,9 @@ from .__about__ import __version__
 from ._mesh import Mesh
 
 exodus_to_meshio_type = {
+    #
+    "SPHERE": "vertex",
+    "CIRCLE": "vertex",
     # curves
     "BEAM": "line",
     "BEAM2": "line",


### PR DESCRIPTION
It appears there is a notion of a vertex element in exodus not covered currently.

There is a SPHERE and a CIRCLE. I added these two to meshio and it appears to work for reading and writing.

I tested the converting a file with sphere nodes from exodus to vtu :
[input file: wave_in_bar.zip](https://github.com/nschloe/meshio/files/3785569/wave_in_bar.zip)

For testing the writer:
I generated a unit cube with 8 hexs in gmsh and couldn't export it to exodus format, hence this fix and  testing.

```python
import pygmsh
import meshio
import numpy as np

geom = pygmsh.built_in.Geometry()

x_pt =  [0.0, 0.0, 0.0]
x_dir = [1.0, 0.0, 0.0]
y_dir = [0.0, 1.0, 0.0]
z_dir = [0.0, 0.0, 1.0]

lay = [2, 2, 2]


point_y = geom.add_point(x_pt) # starting point

# extrude line
_, ex_line, _ = geom.extrude(
        point_y, translation_axis=x_dir, num_layers=lay[0], recombine=True
    )

#extrude rectangle
_, rectangle, _ = geom.extrude(
        ex_line, translation_axis=y_dir, num_layers=lay[1], recombine=True
    )

#extrude bar
geom.extrude(
        rectangle,
        translation_axis=z_dir,
        num_layers=lay[2],
        recombine=True,
    )

#3D mesh
mesh = pygmsh.generate_mesh(geom, geo_filename="cube.geo")

meshio.write("cube.vtu", mesh)
meshio.write("cube.e", mesh)
```