### PR TITLE
Allow XDMF meshes to be 1D.

### DIFF
--- a/meshio/_xdmf/main.py
+++ b/meshio/_xdmf/main.py
@@ -340,7 +340,9 @@ class XdmfWriter:
     def points(self, grid, points):
         from lxml import etree as ET
 
-        if points.shape[1] == 2:
+        if points.shape[1] == 1:
+            geometry_type = "X"
+        elif points.shape[1] == 2:
             geometry_type = "XY"
         else:
             assert points.shape[1] == 3


### PR DESCRIPTION
I'd like to use meshio to convert 1D gmsh meshes to xdmf.  This super simple change allows that but let me know if there are implications I haven't considered.

Thanks!