### PR TITLE
Use open instead of codecs.open

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import codecs
 import os
 
 from setuptools import find_packages, setup
@@ -11,7 +10,7 @@ with open(os.path.join(base_dir, "meshio", "__about__.py"), "rb") as f:
 
 
 def read(fname):
-    return codecs.open(os.path.join(base_dir, fname), encoding="utf-8").read()
+    return open(os.path.join(base_dir, fname), encoding="utf-8").read()
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,6 @@ with open(os.path.join(base_dir, "meshio", "__about__.py"), "rb") as f:
     exec(f.read(), about)
 
 
-def read(fname):
-    return open(os.path.join(base_dir, fname), encoding="utf-8").read()
-
-
 setup(
     name="meshio",
     version=about["__version__"],
@@ -20,7 +16,7 @@ setup(
     author_email=about["__author_email__"],
     packages=find_packages(),
     description="I/O for various mesh formats",
-    long_description=read("README.md"),
+    long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/nschloe/meshio",
     project_urls={


### PR DESCRIPTION
codecs.open is obsolete in python 3.x. open in python 3.x has an
encoding argument. For more info, check out this [question](https://stackoverflow.com/questions/5250744/difference-between-open-and-codecs-open-in-python).