### PR TITLE
Fix reading 1st order wedges for Nastran

### DIFF
--- a/meshio/_nastran.py
+++ b/meshio/_nastran.py
@@ -207,7 +207,7 @@ def _determine_solid_2nd(f, cell_type):
             cell_type = "tetra10"
         elif cell_type == "pyramid":
             cell_type = "pyramid13"
-    else:
+    elif element_lines == 3:
         if cell_type == "wedge":
             cell_type = "wedge15"
         elif cell_type == "hexahedron":


### PR DESCRIPTION
Without this, 
``` python
mesh = meshio.read("test/meshes/flac3d/flac3d_mesh_ex.f3grid")
meshio.write("test.fem", mesh)
meshio.read("test.fem")  # error
```
will raise
```
    109                 cell = [points_id_dict[int(i)] for i in chunks[3:]]
    110                 chunks = _chunk_string(f.readline())
--> 111                 cell.extend([points_id_dict[int(i)] for i in chunks[1:]])
    112                 if n_nodes >= 15:
    113                     chunks = _chunk_string(f.readline())

ValueError: invalid literal for int() with base 10: ''
```

1st wedge elements only have 1 line for the Nastran format, while 2nd elements have 3 lines.