### PR TITLE
Black-compatible isort configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,10 @@ jobs:
       - image: circleci/python:3.7
     steps:
       - checkout
-      - run: pip3 install -U black flake8 --user
+      - run: pip3 install -U black flake8 isort --user
       - run: black --check .
       - run: flake8 .
+      - run: isort --check-only -rc .
   build:
     working_directory: ~/work
     docker:

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
-ignore = E203, E266, W503
-max-line-length = 88
+ignore = E203, E266, E501, W503
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503
-max-line-length = 80
+ignore = E203, E266, W503
+max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=80

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
-line_length=80
+line_length=88

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,5 @@
+;See "a compatible `.isort.cfg`" on the Black website
+;https://black.readthedocs.io/en/stable/the_black_code_style.html
 [settings]
 multi_line_output=3
 include_trailing_comma=True

--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,6 @@ black:
 	black .
 
 lint:
+	isort --check-only -rc .
 	black --check .
 	flake8 .


### PR DESCRIPTION
Currently, `make format` causes `isort` to reformat imports, and then `black` to undo those changes. This configuration should prevent isort making black-incompatible changes.

See "a compatible \`.isort.cfg\`" on the Black website https://black.readthedocs.io/en/stable/the_black_code_style.html