### PR TITLE
simple line_mesh for the test suite

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -14,6 +14,12 @@ MESHES_DIR = TEST_DIR / "meshes"
 # In general:
 # Use values with an infinite decimal representation to test precision.
 
+line_mesh = meshio.Mesh(
+    numpy.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
+    / 3,
+    {"line": numpy.array([[0, 1], [0, 2], [0, 3], [1, 2], [2, 3]])},
+)
+
 tri_mesh_2d = meshio.Mesh(
     numpy.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]) / 3,
     {"triangle": numpy.array([[0, 1, 2], [0, 2, 3]])},

--- a/test/test_abaqus.py
+++ b/test/test_abaqus.py
@@ -29,9 +29,7 @@ def test(mesh):
     return
 
 
-@pytest.mark.parametrize(
-    "filename, ref_sum, ref_num_cells", [("UUea.inp", 4950.0, 50)],
-)
+@pytest.mark.parametrize("filename, ref_sum, ref_num_cells", [("UUea.inp", 4950.0, 50)])
 @pytest.mark.parametrize("binary", [False, True])
 def test_reference_file(filename, ref_sum, ref_num_cells, binary):
     this_dir = os.path.dirname(os.path.abspath(__file__))

--- a/test/test_gmsh.py
+++ b/test/test_gmsh.py
@@ -22,6 +22,7 @@ def gmsh_periodic():
 @pytest.mark.parametrize(
     "mesh",
     [
+        helpers.line_mesh,
         helpers.tri_mesh,
         helpers.triangle6_mesh,
         helpers.quad_mesh,

--- a/test/test_mdpa.py
+++ b/test/test_mdpa.py
@@ -7,6 +7,7 @@ import meshio
 @pytest.mark.parametrize(
     "mesh",
     [
+        helpers.line_mesh,
         helpers.tri_mesh,
         helpers.triangle6_mesh,
         helpers.quad_mesh,

--- a/test/test_med.py
+++ b/test/test_med.py
@@ -12,6 +12,7 @@ h5py = pytest.importorskip("h5py")
 @pytest.mark.parametrize(
     "mesh",
     [
+        helpers.line_mesh,
         helpers.tri_mesh_2d,
         helpers.tri_mesh,
         helpers.triangle6_mesh,

--- a/test/test_medit.py
+++ b/test/test_medit.py
@@ -7,6 +7,7 @@ import meshio
 @pytest.mark.parametrize(
     "mesh",
     [
+        helpers.line_mesh,
         helpers.tri_mesh,
         helpers.tri_mesh_2d,
         helpers.quad_mesh,

--- a/test/test_moab.py
+++ b/test/test_moab.py
@@ -7,7 +7,7 @@ h5py = pytest.importorskip("h5py")
 
 
 @pytest.mark.parametrize(
-    "mesh", [helpers.tri_mesh, helpers.tri_mesh_2d, helpers.tet_mesh]
+    "mesh", [helpers.line_mesh, helpers.tri_mesh, helpers.tri_mesh_2d, helpers.tet_mesh]
 )
 def test_io(mesh):
     helpers.write_read(meshio._h5m.write, meshio._h5m.read, mesh, 1.0e-15)

--- a/test/test_permas.py
+++ b/test/test_permas.py
@@ -7,6 +7,7 @@ import meshio
 @pytest.mark.parametrize(
     "mesh",
     [
+        helpers.line_mesh,
         helpers.tri_mesh,
         # helpers.triangle6_mesh,
         helpers.quad_mesh,

--- a/test/test_svg.py
+++ b/test/test_svg.py
@@ -9,7 +9,7 @@ import meshio
 lxml = pytest.importorskip("lxml")
 
 
-test_set = [helpers.tri_mesh, helpers.tri_mesh_2d, helpers.quad_mesh]
+test_set = [helpers.line_mesh, helpers.tri_mesh, helpers.tri_mesh_2d, helpers.quad_mesh]
 
 
 @pytest.mark.parametrize("mesh", test_set)

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -9,6 +9,7 @@ import helpers
 import meshio
 
 test_set = [
+    helpers.line_mesh,
     helpers.tri_mesh_2d,
     helpers.tri_mesh,
     helpers.triangle6_mesh,

--- a/test/test_vtu.py
+++ b/test/test_vtu.py
@@ -6,6 +6,7 @@ import meshio
 lxml = pytest.importorskip("lxml")
 
 test_set = [
+    helpers.line_mesh,
     helpers.tri_mesh,
     helpers.triangle6_mesh,
     helpers.quad_mesh,


### PR DESCRIPTION
PR #564 ‘only read XDMF Polyline of 2 points’ failed a coverage test.  There aren't any meshes with cells of type `'line'` in `test.helpers`, so here's one.
