### PR TITLE
Python 3.5 compatibility

### DIFF
--- a/meshio/wkt/_wkt.py
+++ b/meshio/wkt/_wkt.py
@@ -20,7 +20,7 @@ triangle_pattern = r"\(\s*\(\s*({})\s*\)\s*\)".format(
 )
 triangle_re = re.compile(triangle_pattern)
 
-tin_pattern = rf"TIN\s*\((?:\s*{triangle_pattern}\s*,?)*\s*\)"
+tin_pattern = r"TIN\s*\((?:\s*{}\s*,?)*\s*\)".format(triangle_pattern)
 tin_re = re.compile(tin_pattern)
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     platforms="any",
     install_requires=["numpy"],
     # For pathlib:
-    python_requires=">=3.4",
+    python_requires=">=3.5",
     extras_require=extras,
     classifiers=[
         about["__status__"],

--- a/test/performance.py
+++ b/test/performance.py
@@ -130,7 +130,7 @@ def read_write(plot=False):
     mesh = generate_mesh()
     mem_size = mesh.points.nbytes + mesh.cells["tetra"].nbytes
     mem_size /= 1024.0 ** 2
-    print(f"mem_size: {mem_size:.2f} MB")
+    print("mem_size: {:.2f} MB".format(mem_size))
 
     formats = {
         "Abaqus": (meshio.abaqus.write, meshio.abaqus.read, ["out.inp"]),


### PR DESCRIPTION
Removes a couple of f-strings which had snuck in (because they're great).

Also updates package metadata to only support python >= 3.5 (because 3.4 is EOL).