### PR TITLE
Improve FLAC3D read and write performances (Issue #584)

### DIFF
--- a/meshio/flac3d/_flac3d.py
+++ b/meshio/flac3d/_flac3d.py
@@ -17,13 +17,14 @@ meshio_only = {"tetra", "pyramid", "wedge", "hexahedron"}
 meshio_data = {"flac3d:zone", "gmsh:physical", "medit:ref"}
 
 
-flac3d_to_meshio_type = {
-    "T4": "tetra",
-    "P5": "pyramid",
-    "W6": "wedge",
-    "B7": "hexahedron",
-    "B8": "hexahedron",
+numnodes_to_meshio_type = {
+    4: "tetra",
+    5: "pyramid",
+    6: "wedge",
+    8: "hexahedron",
 }
+
+
 meshio_to_flac3d_type = {
     "tetra": "T4",
     "pyramid": "P5",
@@ -73,100 +74,90 @@ def read_buffer(f):
     """
     points = []
     point_ids = {}
-    zones = {}
-    zgroups = {}
-    count = {k: 0 for k in meshio_to_flac3d_type.keys()}
+    cells = {}
+    mapper = {}
+    field_data = {}
+    slots = set()
 
-    index = 0
+    pidx = 0
+    zidx = 0
+    count = {k: 0 for k in meshio_only}
     line = f.readline()
     while line:
-        if line.startswith("ZGROUP"):
-            _read_zgroup(f, line, zgroups)
-        elif line.startswith("G"):
-            pid = _read_point(line, points)
-            point_ids[pid] = index
-            index += 1
-        elif line.startswith("Z"):
-            _read_cell(line, zones, count, point_ids)
+        line = line.rstrip().split()
+        if line[0] == "G":
+            pid, point = _read_point(line)
+            points.append(point)
+            point_ids[pid] = pidx
+            pidx += 1
+        elif line[0] == "Z":
+            cid, cell = _read_cell(line, point_ids)
+            cell_type = numnodes_to_meshio_type[len(cell)]
+            if cell_type in cells:
+                cells[cell_type].append(cell)
+            else:
+                cells[cell_type] = [cell]
+            mapper[cid] = [count[cell_type], len(cell)]
+            count[cell_type] += 1
+        elif line[0] == "ZGROUP":
+            name, data, slot = _read_zgroup(f, line)
+            zidx += 1
+            for cid in data:
+                mapper[cid].append(zidx)
+            field_data[name] = numpy.array([zidx, 3])
+            slots.add(slot)
+            assert len(slots) == 1, "Multiple slots are not supported."
         line = f.readline()
 
-    cells, cell_data, field_data = _translate_cells(zones, zgroups, count)
+    cell_data = {k: {"flac3d:zone": numpy.zeros(v)} for k, v in count.items() if v}
+    for i, numnodes, zid in mapper.values():
+        cell_data[numnodes_to_meshio_type[numnodes]]["flac3d:zone"][i] = zid
+
     return Mesh(
         points=numpy.array(points),
-        cells=cells,
+        cells={k: numpy.array(v) for k, v in cells.items()},
         cell_data=cell_data,
         field_data=field_data,
     )
 
 
-def _read_point(line, points):
+def _read_point(line):
     """
     Read point coordinates.
     """
-    line = line.rstrip().split()
-    points.append([float(l) for l in line[2:]])
-    return int(line[1])
+    return int(line[1]), [float(l) for l in line[2:]]
 
 
-def _read_cell(line, zones, count, point_ids):
+def _read_cell(line, point_ids):
     """
     Read cell corners.
     """
-    line = line.rstrip().split()
-    meshio_type = flac3d_to_meshio_type[line[1]]
     cell = [point_ids[int(l)] for l in line[3:]]
     if line[1] == "B7":
         cell.append(cell[-1])
-    zones[int(line[2])] = {
-        "meshio_id": count[meshio_type],
-        "meshio_type": meshio_type,
-        "cell": [cell[i] for i in flac3d_to_meshio_order[meshio_type]],
-    }
-    count[meshio_type] += 1
+    return int(line[2]), cell
 
 
-def _read_zgroup(f, line, zgroups):
+def _read_zgroup(f, line):
     """
     Read cell group.
     """
-    group_name = line.rstrip().split()[1].replace('"', "")
-    zgroups[group_name] = []
+    name = line[1].replace('"', "")
+    data = []
+    slot = "" if "SLOT" not in line else line[-1]
 
     i = f.tell()
     line = f.readline()
     while True:
         line = line.rstrip().split()
-        if line and (line[0] not in ["*", "ZGROUP"]):
-            zgroups[group_name].extend([int(l) for l in line])
+        if line and (line[0] not in {"*", "ZGROUP"}):
+            data += [int(l) for l in line]
         else:
             f.seek(i)
             break
         i = f.tell()
         line = f.readline()
-
-
-def _translate_cells(zones, zgroups, count):
-    """
-    Convert FLAC3D zones and groups as meshio cells and cell_data.
-    """
-    meshio_types = [k for k in meshio_to_flac3d_type.keys() if count[k]]
-    cells = {k: [] for k in meshio_types}
-    cell_data = {k: numpy.zeros(count[k]) for k in meshio_types}
-    field_data = {}
-
-    for v in zones.values():
-        cells[v["meshio_type"]].append(v["cell"])
-
-    for zid, (k, v) in enumerate(zgroups.items()):
-        field_data[k] = numpy.array([zid + 1, 3])
-        for i in v:
-            mid = zones[i]["meshio_id"]
-            mt = zones[i]["meshio_type"]
-            cell_data[mt][mid] = zid + 1
-
-    cells = {k: numpy.array(v) for k, v in cells.items()}
-    cell_data = {k: {"flac3d:zone": v} for k, v in cell_data.items()}
-    return cells, cell_data, field_data
+    return name, data, slot
 
 
 def write(filename, mesh):

--- a/meshio/flac3d/_flac3d.py
+++ b/meshio/flac3d/_flac3d.py
@@ -118,7 +118,7 @@ def read_buffer(f):
 
     return Mesh(
         points=numpy.array(points),
-        cells={k: numpy.array(v) for k, v in cells.items()},
+        cells={k: numpy.array(v)[:,flac3d_to_meshio_order[k]] for k, v in cells.items()},
         cell_data=cell_data,
         field_data=field_data,
     )

--- a/meshio/flac3d/_flac3d.py
+++ b/meshio/flac3d/_flac3d.py
@@ -118,7 +118,9 @@ def read_buffer(f):
 
     return Mesh(
         points=numpy.array(points),
-        cells={k: numpy.array(v)[:,flac3d_to_meshio_order[k]] for k, v in cells.items()},
+        cells={
+            k: numpy.array(v)[:, flac3d_to_meshio_order[k]] for k, v in cells.items()
+        },
         cell_data=cell_data,
         field_data=field_data,
     )

--- a/meshio/flac3d/_flac3d.py
+++ b/meshio/flac3d/_flac3d.py
@@ -10,6 +10,7 @@ from .._exceptions import WriteError
 from .._files import open_file
 from .._helpers import register
 from .._mesh import Mesh
+from .._exceptions import ReadError
 
 meshio_only = {"tetra", "pyramid", "wedge", "hexahedron"}
 
@@ -106,7 +107,8 @@ def read_buffer(f):
                 mapper[cid].append(zidx)
             field_data[name] = numpy.array([zidx, 3])
             slots.add(slot)
-            assert len(slots) == 1, "Multiple slots are not supported."
+            if len(slots) > 1:
+                raise ReadError("Multiple slots are not supported")
         line = f.readline()
 
     if zidx:

--- a/meshio/flac3d/_flac3d.py
+++ b/meshio/flac3d/_flac3d.py
@@ -6,11 +6,10 @@ import time
 import numpy
 
 from ..__about__ import __version__ as version
-from .._exceptions import WriteError
+from .._exceptions import ReadError, WriteError
 from .._files import open_file
 from .._helpers import register
 from .._mesh import Mesh
-from .._exceptions import ReadError
 
 meshio_only = {"tetra", "pyramid", "wedge", "hexahedron"}
 


### PR DESCRIPTION
- Changed: refactor reader code to rely less on dictionaries,
- Changed: zone groups are no longer written if not recognized or ``cell_data`` is empty,
- Added: handle non-naturally ordered cells.

**Remarks**
1. I still need to use some dictionaries to handle non-natural order of points and cells since the format does not provide how many points and cells are in the mesh,
2. The conversion of  ``cells`` to ``numpy.ndarray`` in the reader uses some memory. I have no idea how to append directly to a ``numpy`` array in place.

**Results**
On an example of mine (100K points and 570K tetra), the old reader used 300 MB down to 200 MB with the new reader. The new reader is also slightly faster compared to the old one.