### PR TITLE
Multi-version testing configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ shared: &shared
     - checkout
     - run: git lfs pull
     - run: pip install .[all] --user
+    - run: pytest --cov
     - run: |
         if [ $UPLOAD_COV ]; then
           bash <(curl -s https://codecov.io/bash)
@@ -37,9 +38,8 @@ jobs:
       - image: circleci/python:3.5
 
   lint:
-    <<: *shared
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - checkout
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: circleci/python:3.8
     steps:
-      - run: pip install tox tox-pyenv
+      - run: pip install tox tox-pyenv --user
       - run: pyenv global 3.8.0 3.7.5 3.6.9 3.5.9
       - checkout
       - run: tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
     docker:
       - image: circleci/python:3.7
     steps:
+      - checkout
       - run: |
           # For isort, must install all "system" dependencies
           pip3 install isort --user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,45 +1,12 @@
 version: 2
 
 jobs:
-  lint:
-    docker:
-      - image: circleci/python:3.7
-    steps:
-      - checkout
-      - run: |
-          # For isort, must install all "system" dependencies
-          pip3 install isort --user
-          pip3 install .[all] --user
-          pip3 install pytest --user
-          isort -rc -c .
-      - run: |
-          pip3 install black --user
-          black --check .
-      - run: |
-          pip3 install flake8 --user
-          flake8 .
   build:
-    working_directory: ~/work
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
-      # <https://stackoverflow.com/a/44333806/353337>
-      - run: DEBIAN_FRONTEND=noninteractive sudo apt-get install tzdata
-      - run: sudo apt-get install -y git git-lfs python3-h5py python3-netcdf4 python3-lxml
-      - run: pip3 install -U pytest pytest-cov --user
+      - run: pip install tox tox-pyenv
+      - run: pyenv global 3.8.0 3.7.5 3.6.9 3.5.9
       - checkout
-      - run: git lfs pull
-      # The actual test
-      - run: pip3 install .[all] --user
-      - run:
-          command: pytest --cov meshio
-          working_directory: test/
-      # submit to codecov
+      - run: tox
       - run: bash <(curl -s https://codecov.io/bash)
-
-workflows:
-  version: 2
-  lint_and_build:
-    jobs:
-      - lint
-      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,12 @@ version: 2
 
 shared: &shared
   steps:
+    - run: DEBIAN_FRONTEND=noninteractive sudo apt-get install tzdata
+    - run: sudo apt-get install -y git git-lfs python3-h5py python3-netcdf4 python3-lxml
+    - run: pip3 install -U pytest pytest-cov --user
     - checkout
-    - run: pip install tox tox-pyenv --user
-    - run: tox -e $TOX_JOB
+    - run: git lfs pull
+    - run: pip install .[all] --user
     - run: "[ $UPLOAD_COV ] && bash <(curl -s https://codecov.io/bash)"
 
 jobs:
@@ -13,32 +16,47 @@ jobs:
     docker:
       - image: circleci/python:3.8
         environment:
-          TOX_JOB: py38
+          UPLOAD_COV: "true"
 
   py37:
     <<: *shared
     docker:
       - image: circleci/python:3.7
-        environment:
-          TOX_JOB: py37
 
   py36:
     <<: *shared
     docker:
       - image: circleci/python:3.6
-        environment:
-          TOX_JOB: py36
 
   py35:
     <<: *shared
     docker:
       - image: circleci/python:3.5
-        environment:
-          TOX_JOB: py35
 
   lint:
     <<: *shared
     docker:
       - image: circleci/python:3.7
-        environment:
-          TOX_JOB: lint
+    steps:
+      - run: |
+        # For isort, must install all "system" dependencies
+        pip3 install isort --user
+        pip3 install .[all] --user
+        pip3 install pytest --user
+        isort -rc -c .
+      - run: |
+        pip3 install black --user
+        black --check .
+      - run: |
+        pip3 install flake8 --user
+        flake8 .
+
+
+workflows:
+  version: 2
+  test_and_lint:
+    - py38
+    - py37
+    - py36
+    - py35
+    - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,9 @@ jobs:
 workflows:
   version: 2
   test_and_lint:
-    - py38
-    - py37
-    - py36
-    - py35
-    - lint
+    jobs:
+      - py38
+      - py37
+      - py36
+      - py35
+      - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,44 @@
 version: 2
 
+shared: &shared
+  steps:
+    - checkout
+    - run: pip install tox tox-pyenv --user
+    - run: tox -e $TOX_JOB
+    - run: "[ $UPLOAD_COV ] && bash <(curl -s https://codecov.io/bash)"
+
 jobs:
-  build:
+  py38:
+    <<: *shared
     docker:
       - image: circleci/python:3.8
-    steps:
-      - run: pip install tox tox-pyenv --user
-      - run: pyenv global 3.8.0 3.7.5 3.6.9 3.5.9
-      - checkout
-      - run: tox
-      - run: bash <(curl -s https://codecov.io/bash)
+        environment:
+          TOX_JOB: py38
+
+  py37:
+    <<: *shared
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOX_JOB: py37
+
+  py36:
+    <<: *shared
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOX_JOB: py36
+
+  py35:
+    <<: *shared
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOX_JOB: py35
+
+  lint:
+    <<: *shared
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOX_JOB: lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,18 +39,17 @@ jobs:
       - image: circleci/python:3.7
     steps:
       - run: |
-        # For isort, must install all "system" dependencies
-        pip3 install isort --user
-        pip3 install .[all] --user
-        pip3 install pytest --user
-        isort -rc -c .
+          # For isort, must install all "system" dependencies
+          pip3 install isort --user
+          pip3 install .[all] --user
+          pip3 install pytest --user
+          isort -rc -c .
       - run: |
-        pip3 install black --user
-        black --check .
+          pip3 install black --user
+          black --check .
       - run: |
-        pip3 install flake8 --user
-        flake8 .
-
+          pip3 install flake8 --user
+          flake8 .
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,10 @@ shared: &shared
     - checkout
     - run: git lfs pull
     - run: pip install .[all] --user
-    - run: "[ $UPLOAD_COV ] && bash <(curl -s https://codecov.io/bash)"
+    - run: |
+        if [ $UPLOAD_COV ]; then
+          bash <(curl -s https://codecov.io/bash)
+        fi
 
 jobs:
   py38:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ dist/
 doc/_build/
 *.egg-info/
 .pytest_cache/
+*.tox/
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,6 @@ black:
 	black .
 
 lint:
+	isort -rc -c .
 	black --check .
 	flake8 .

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ lxml
 
 # development
 pytest
+pytest-cov
 isort
 black; python_version >= '3.6'
 flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist=lint,py35,py36,py37,py38
+
+[testenv]
+deps=-rrequirements.txt
+commands=
+    pip install .[all]
+    pytest --cov
+
+[testenv:lint]
+basepython=python3.7
+whitelist_externals=make
+deps=-rrequirements.txt
+commands=
+    pip install .[all]
+    make lint


### PR DESCRIPTION
Run tests against all supported versions, as well as linting, with a single command.

Things I'm unsure of:

1. Explicitly installing the dependencies in the `requirements.txt` in each environment. This reduces the number of times we have to specify our development dependencies, but possibly is not a fair test of the normal installation procedure.
2. The circleci configuration got a lot simpler, but we lose parallelism between the lint and build steps. How best to test multiple python versions in parallel is not documented (issue raised here https://github.com/circleci/circleci-docs/issues/4005 ).