### PR TITLE
read TopologyType Mixed  in XDMF2

### DIFF
--- a/meshio/xdmf/main.py
+++ b/meshio/xdmf/main.py
@@ -147,8 +147,12 @@ class XdmfReader:
                 data_items = list(c)
                 if len(data_items) != 1:
                     raise ReadError()
-                meshio_type = xdmf_to_meshio_type[c.attrib["TopologyType"]]
-                cells[meshio_type] = self._read_data_item(data_items[0])
+                topology_type = c.attrib["TopologyType"]
+                if topology_type == "Mixed":
+                    cells = translate_mixed_cells(data_items[0])
+                else:
+                    meshio_type = xdmf_to_meshio_type[topology_type]
+                    cells[meshio_type] = self._read_data_item(data_items[0])
 
             elif c.tag == "Geometry":
                 if "GeometryType" in c.attrib and c.attrib["GeometryType"] != "XYZ":

--- a/meshio/xdmf/main.py
+++ b/meshio/xdmf/main.py
@@ -149,7 +149,14 @@ class XdmfReader:
                     raise ReadError()
                 topology_type = c.attrib["TopologyType"]
                 if topology_type == "Mixed":
-                    cells = translate_mixed_cells(data_items[0])
+                    cells = translate_mixed_cells(
+                        numpy.fromstring(
+                            data_items[0].text,
+                            int,
+                            int(data_items[0].attrib["Dimensions"]),
+                            " ",
+                        )
+                    )
                 else:
                     meshio_type = xdmf_to_meshio_type[topology_type]
                     cells[meshio_type] = self._read_data_item(data_items[0])


### PR DESCRIPTION
This is for #600.  Not extensively tested, since meshio and ParaView 5.7.0 only write XDMF 3.0, so I'm relying on ParaView 5.6.0 and that's buggy, but this is better than what's in master.