### PR TITLE
Improve Nastran reading

### DIFF
--- a/test/meshes/nastran/cylinder_cells_first.fem
+++ b/test/meshes/nastran/cylinder_cells_first.fem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b6d7151d15f16f2267727e474a19388d50106465ebf26af9a1496c7a9edb404
+size 11447

--- a/test/test_nastran.py
+++ b/test/test_nastran.py
@@ -26,14 +26,21 @@ def test(mesh):
     helpers.write_read(meshio.nastran.write, meshio.nastran.read, mesh, 1.0e-15)
 
 
-def test_reference_file():
+@pytest.mark.parametrize("filename", ["cylinder.fem", "cylinder_cells_first.fem"])
+def test_reference_file(filename):
     this_dir = os.path.dirname(os.path.abspath(__file__))
-    filename = os.path.join(this_dir, "meshes", "nastran", "cylinder.fem")
+    filename = os.path.join(this_dir, "meshes", "nastran", filename)
     mesh = meshio.read(filename)
 
     # Points
     assert numpy.isclose(mesh.points.sum(), 16.5316866)
 
     # Cells
-    ref_num_cells = {"pyramid": 18, "quad": 18, "line": 17, "tetra": 63, "triangle": 4}
-    assert {k: len(v) for k, v in mesh.cells.items()} == ref_num_cells
+    ref_num_cells = {
+        "line": 241,
+        "triangle": 171,
+        "quad": 721,
+        "pyramid": 1180,
+        "tetra": 5309,
+    }
+    assert {k: v.sum() for k, v in mesh.cells.items()} == ref_num_cells


### PR DESCRIPTION
- Remove the costly tell / seek for identifying 2nd order solid elements
- Nodes can now be defined after elements
- Correct node ordering for certain cells

1. This fixes #603
2. Reading efficiency is greatly improved for solid elements. For the tetrahedral mesh used for performance benchmarking (400k points and 2M tetrahedra), the time has been reduced from 1 minute to 20 s.

Before
```
CPU times: user 53.7 s, sys: 5.23 s, total: 58.9 s
Wall time: 59 s
```

After
```
CPU times: user 21 s, sys: 705 ms, total: 21.7 s
Wall time: 21.6 s
```
