### PR TITLE
Add methods to iterate over points and cells

### DIFF
--- a/meshio/_mesh.py
+++ b/meshio/_mesh.py
@@ -113,3 +113,27 @@ class Mesh:
         from ._helpers import read
 
         return read(path_or_buf, file_format)
+
+    def iterpoints(self):
+        for i, point in enumerate(self.points):
+            data = (
+                {label: data_array[i] for label, data_array in self.point_data.items()}
+                if self.point_data
+                else {}
+            )
+            yield (point, data)
+
+    def itercells(self):
+        from ._common import num_nodes_per_cell
+
+        for cell_type in sorted(self.cells.keys(), key=lambda x: num_nodes_per_cell[x]):
+            for i, corner in enumerate(self.cells[cell_type]):
+                data = (
+                    {
+                        label: data_array[i]
+                        for label, data_array in self.cell_data[cell_type].items()
+                    }
+                    if cell_type in self.cell_data
+                    else {}
+                )
+                yield (corner, data, cell_type)


### PR DESCRIPTION
- Added: ``Mesh.iterpoints`` to iterate over points, it returns a generator that returns a tuple with the point coordinates and a dict with the point data associated with the current point,
- Added: ``Mesh.itercells`` to iterate over cells, it returns a generator that returns a tuple with the cell corner points, a dict the cell data associated with the current cell, and the current cell type.

**Usage**

```python
for point in mesh.iterpoints():
    # Do something with point coordinates and/or data

for cell in mesh.itercells():
    # Do something with cell corner points, data and/or type
```

**Comment**
- Sometimes, we just want to iterate over point/cell and their data at the same time and it usually ends up with complicated nested for loops (especially with cells). These methods provide a simple way to iterate over points and cells with a single for loop,
- In ``python < 3.7``, dicts are iterated based on the hash value of their keys while in ``python >= 3.7``, dicts are iterated in the same order as they were defined. This results in inconsistent order of iteration when iterating over cells, depending on the Python environment. In ``Mesh.itercells``, the cells are iterated over depending on the number of nodes providing consistency across the different versions of Python.