### PR TITLE
Fix bug in FLAC3D reader

### DIFF
--- a/meshio/flac3d/_flac3d.py
+++ b/meshio/flac3d/_flac3d.py
@@ -96,9 +96,8 @@ def read_buffer(f):
     pidx = 0
     zidx = 0
     count = 0
-    line = f.readline()
+    line = f.readline().rstrip().split()
     while line:
-        line = line.rstrip().split()
         if line[0] == "G":
             pid, point = _read_point(line)
             points.append(point)
@@ -122,7 +121,7 @@ def read_buffer(f):
             slots.add(slot)
             if len(slots) > 1:
                 raise ReadError("Multiple slots are not supported")
-        line = f.readline()
+        line = f.readline().rstrip().split()
 
     if zidx:
         n_cells = numpy.cumsum([len(c[1]) for c in cells])

--- a/meshio/flac3d/_flac3d.py
+++ b/meshio/flac3d/_flac3d.py
@@ -125,7 +125,7 @@ def read_buffer(f):
 
     if zidx:
         n_cells = numpy.cumsum([len(c[1]) for c in cells])
-        cell_data = numpy.empty(n_cells[-1])
+        cell_data = numpy.empty(n_cells[-1], dtype=int)
         for cid, zid in mapper.values():
             cell_data[cid] = zid
         cell_data = {"flac3d:zone": numpy.split(cell_data, n_cells[:-1])}


### PR DESCRIPTION
- Fixed: reader would throw an error if for some reasons input file ends with extra empty lines. Fix simply consists in making ``while`` loop consistently checking the truth value of a list (is empty or not).