### PR TITLE
Read cell sets from Abaqus INP files using new the cells structure

### DIFF
--- a/meshio/_mesh.py
+++ b/meshio/_mesh.py
@@ -53,6 +53,9 @@ class Mesh:
         if self.point_sets:
             lines.append("  Point sets: {}".format(", ".join(self.point_sets.keys())))
 
+        if self.cell_sets:
+            lines.append("  Cell sets: {}".format(", ".join(self.cell_sets.keys())))
+
         if self.point_data:
             lines.append("  Point data: {}".format(", ".join(self.point_data.keys())))
 

--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -120,22 +120,22 @@ def read_buffer(f):
             line = f.readline()
             continue
 
-        keyword = line.strip("*")
-        if keyword.upper().startswith("NODE"):
+        keyword = line.partition(",")[0].strip().replace("*", "").upper()
+        if keyword == "NODE":
             points, point_ids, line = _read_nodes(f)
-        elif keyword.upper().startswith("ELEMENT"):
-            cell_type, cells_data, ids, line = _read_cells(f, keyword, point_ids)
+        elif keyword == "ELEMENT":
+            cell_type, cells_data, ids, line = _read_cells(f, line, point_ids)
             cells.append(Cells(cell_type, cells_data))
             cell_ids.append(ids)
-        elif keyword.upper().startswith("NSET"):
-            params_map = get_param_map(keyword, required_keys=["NSET"])
+        elif keyword == "NSET":
+            params_map = get_param_map(line, required_keys=["NSET"])
             set_ids, line = _read_set(f, params_map)
             name = params_map["NSET"]
             point_sets[name] = numpy.array(
                 [point_ids[point_id] for point_id in set_ids], dtype="int32"
             )
-        elif keyword.upper().startswith("ELSET"):
-            params_map = get_param_map(keyword, required_keys=["ELSET"])
+        elif keyword == "ELSET":
+            params_map = get_param_map(line, required_keys=["ELSET"])
             set_ids, line = _read_set(f, params_map)
             name = params_map["ELSET"]
             cell_sets[name] = []

--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -254,15 +254,11 @@ def _read_set(f, params_map):
 
         set_ids += [int(k) for k in line.strip().strip(",").split(",")]
 
+    set_ids = numpy.array(set_ids, dtype="int32")
     if "GENERATE" in params_map:
         if len(set_ids) != 3:
             raise ReadError(set_ids)
-        set_ids = numpy.arange(set_ids[0], set_ids[1] + 1, set_ids[2])
-    else:
-        try:
-            set_ids = numpy.unique(numpy.array(set_ids, dtype="int32"))
-        except ValueError:
-            raise ReadError(set_ids)
+        set_ids = numpy.arange(set_ids[0], set_ids[1] + 1, set_ids[2], dtype="int32")
     return set_ids, line
 
 

--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -103,6 +103,7 @@ def read(filename):
 def read_buffer(f):
     # Initialize the optional data fields
     cells = []
+    cell_ids = []
     point_sets = {}
     cell_sets = {}
     field_data = {}
@@ -123,8 +124,9 @@ def read_buffer(f):
         if keyword.upper().startswith("NODE"):
             points, point_ids, line = _read_nodes(f)
         elif keyword.upper().startswith("ELEMENT"):
-            key, idx, line = _read_cells(f, keyword, point_ids)
-            cells.append(Cells(key, idx))
+            cell_type, cells_data, ids, line = _read_cells(f, keyword, point_ids)
+            cells.append(Cells(cell_type, cells_data))
+            cell_ids.append(ids)
         elif keyword.upper().startswith("NSET"):
             params_map = get_param_map(keyword, required_keys=["NSET"])
             set_ids, line = _read_set(f, params_map)
@@ -134,11 +136,15 @@ def read_buffer(f):
             )
         elif keyword.upper().startswith("ELSET"):
             params_map = get_param_map(keyword, required_keys=["ELSET"])
-            setids, line = _read_set(f, params_map)
+            set_ids, line = _read_set(f, params_map)
             name = params_map["ELSET"]
-            if name not in cell_sets:
-                cell_sets[name] = []
-            cell_sets[name].append(setids - 1)
+            cell_sets[name] = []
+            for cell_ids_ in cell_ids:
+                cell_sets_ = numpy.array(
+                    [cell_ids_[set_id] for set_id in set_ids if set_id in cell_ids_],
+                    dtype="int32",
+                )
+                cell_sets[name].append(cell_sets_)
         else:
             # There are just too many Abaqus keywords to explicitly skip them.
             line = f.readline()
@@ -157,7 +163,7 @@ def read_buffer(f):
 def _read_nodes(f):
     points = []
     point_ids = {}
-    index = 0
+    counter = 0
     while True:
         line = f.readline()
         if not line or line.startswith("*"):
@@ -167,9 +173,9 @@ def _read_nodes(f):
 
         line = line.strip().split(",")
         point_id, coords = line[0], line[1:]
-        point_ids[int(point_id)] = index
+        point_ids[int(point_id)] = counter
         points.append([float(x) for x in coords])
-        index += 1
+        counter += 1
 
     return numpy.array(points, dtype=float), point_ids, line
 
@@ -188,6 +194,8 @@ def _read_cells(f, line0, point_ids):
     cell_type = abaqus_to_meshio_type[etype]
 
     cells, idx = [], []
+    cell_ids = {}
+    counter = 0
     while True:
         line = f.readline()
         if not line or line.startswith("*"):
@@ -198,10 +206,11 @@ def _read_cells(f, line0, point_ids):
         line = line.strip()
         idx += [int(k) for k in filter(None, line.split(","))]
         if not line.endswith(","):
-            # the first item is just a running index
+            cell_ids[idx[0]] = counter
             cells.append([point_ids[k] for k in idx[1:]])
             idx = []
-    return cell_type, numpy.array(cells), line
+            counter += 1
+    return cell_type, numpy.array(cells), cell_ids, line
 
 
 def get_param_map(word, required_keys=None):

--- a/test/meshes/abaqus/README.md
+++ b/test/meshes/abaqus/README.md
@@ -1,1 +1,2 @@
 * `UUea.inp`: From http://www-h.eng.cam.ac.uk/help/programs/fe/abaqus/faq68/txt/UUea.inp.txt
+* `nle1xf3c.inp`: From http://dsk.ippt.pan.pl/docs/abaqus/v6.13/books/eif/nle1xf3c.inp

--- a/test/meshes/abaqus/nle1xf3c.inp
+++ b/test/meshes/abaqus/nle1xf3c.inp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d8bc83d571066e10faac3fe9b43d1c91d02ec6ab89903f479e0d3546a7cc424
+size 1850

--- a/test/test_abaqus.py
+++ b/test/test_abaqus.py
@@ -28,15 +28,15 @@ def test(mesh):
     helpers.write_read(writer, meshio.abaqus.read, mesh, 1.0e-15)
 
 
-@pytest.mark.parametrize("filename, ref_sum, ref_num_cells", [("UUea.inp", 4950.0, 50)])
-@pytest.mark.parametrize("binary", [False, True])
-def test_reference_file(filename, ref_sum, ref_num_cells, binary):
+@pytest.mark.parametrize(
+    "filename, ref_sum, ref_num_cells, ref_num_cell_sets",
+    [("UUea.inp", 4950.0, 50, 10), ("nle1xf3c.inp", 32.215275528, 12, 2)],
+)
+def test_reference_file(filename, ref_sum, ref_num_cells, ref_num_cell_sets):
     this_dir = os.path.dirname(os.path.abspath(__file__))
     filename = os.path.join(this_dir, "meshes", "abaqus", filename)
     mesh = meshio.read(filename)
-    tol = 1.0e-2
-    s = numpy.sum(mesh.points)
-    assert abs(s - ref_sum) < tol * abs(ref_sum)
-    for cells in mesh.cells:
-        if cells.type == "quad":
-            assert len(cells.data) == ref_num_cells
+
+    assert numpy.isclose(numpy.sum(mesh.points), ref_sum)
+    assert sum([len(cells.data) for cells in mesh.cells]) == ref_num_cells
+    assert len(mesh.cell_sets) == ref_num_cell_sets


### PR DESCRIPTION
With the new cells / cell_data structure, if we have three types of cells
```
mesh.cells = [("triangle", ...), ("quad", ...), ("quad8", ...)]
```
and a particular cell set `A` is composed of the 1st `triangle` element, as well as the 2nd and the 6th `quad8` elements, we will have
```
mesh.cell_sets["A"] = [[0], [], [1, 5]]
```

1. Note that lists (and not Python sets) are used, since I would like to preserve cell id's ordering as specified in the file.
2. If the current cell set doesn't contain a certain cell type, then an empty list is used.