### PR TITLE
allow default binary=True to be overridden in writing STL

### DIFF
--- a/meshio/stl/_stl.py
+++ b/meshio/stl/_stl.py
@@ -228,6 +228,6 @@ register(
     {
         "stl-ascii": lambda f, m, **kwargs: write(f, m, **kwargs, binary=False),
         "stl-binary": lambda f, m, **kwargs: write(f, m, **kwargs, binary=True),
-        "stl": lambda f, m, **kwargs: write(f, m, **kwargs, binary=True),
+        "stl": lambda f, m, **kwargs: write(f, m, **{'binary': True, **kwargs}),
     },
 )

--- a/meshio/stl/_stl.py
+++ b/meshio/stl/_stl.py
@@ -228,6 +228,6 @@ register(
     {
         "stl-ascii": lambda f, m, **kwargs: write(f, m, **kwargs, binary=False),
         "stl-binary": lambda f, m, **kwargs: write(f, m, **kwargs, binary=True),
-        "stl": lambda f, m, **kwargs: write(f, m, **{'binary': True, **kwargs}),
+        "stl": lambda f, m, **kwargs: write(f, m, **{"binary": True, **kwargs}),
     },
 )


### PR DESCRIPTION
Fixes #669.