### PR TITLE
Bug fix and test VARLOCATION for Tecplot

### DIFF
--- a/meshio/tecplot/_tecplot.py
+++ b/meshio/tecplot/_tecplot.py
@@ -395,7 +395,7 @@ def write(filename, mesh):
         num_cells = sum(len(mesh.cells[ic].data) for ic in cell_blocks)
         f.write(f"ZONE NODES = {num_nodes}, ELEMENTS = {num_cells},\n")
         f.write(f"DATAPACKING = BLOCK, ZONETYPE = {zone_type}")
-        if varrange[0] < varrange[1]:
+        if varrange[0] <= varrange[1]:
             f.write(",\n")
             varlocation_str = (
                 f"{varrange[0]}"

--- a/test/test_tecplot.py
+++ b/test/test_tecplot.py
@@ -1,3 +1,4 @@
+import numpy
 import pytest
 
 import helpers
@@ -9,3 +10,37 @@ import meshio
 )
 def test(mesh):
     helpers.write_read(meshio.tecplot.write, meshio.tecplot.read, mesh, 1.0e-15)
+
+
+def test_varlocation():
+    # Test that VARLOCATION is correctly written and read depending on the
+    # number of point and cell data.
+    writer = meshio.tecplot.write
+    reader = meshio.tecplot.read
+    mesh = helpers.tri_mesh
+    num_points = len(mesh.points)
+    num_cells = sum(len(c.data) for c in mesh.cells)
+
+    # Add point data: no VARLOCATION
+    mesh.point_data["one"] = numpy.ones(num_points)
+    helpers.write_read(writer, reader, mesh, 1.0e-15)
+
+    # Add cell data: VARLOCATION = ([5] = CELLCENTERED)
+    mesh.cell_data["two"] = [numpy.ones(num_cells) * 2.0]
+    helpers.write_read(writer, reader, mesh, 1.0e-15)
+
+    # Add point data: VARLOCATION = ([6] = CELLCENTERED)
+    mesh.point_data["three"] = numpy.ones(num_points) * 3.0
+    helpers.write_read(writer, reader, mesh, 1.0e-15)
+
+    # Add cell data: VARLOCATION = ([6-7] = CELLCENTERED)
+    mesh.cell_data["four"] = [numpy.ones(num_cells) * 4.0]
+    helpers.write_read(writer, reader, mesh, 1.0e-15)
+
+    # Add point data: VARLOCATION = ([7-8] = CELLCENTERED)
+    mesh.point_data["five"] = numpy.ones(num_points) * 5.0
+    helpers.write_read(writer, reader, mesh, 1.0e-15)
+
+    # Add cell data: VARLOCATION = ([7-9] = CELLCENTERED)
+    mesh.cell_data["six"] = [numpy.ones(num_cells) * 6.0]
+    helpers.write_read(writer, reader, mesh, 1.0e-15)

--- a/test/test_tecplot.py
+++ b/test/test_tecplot.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import numpy
 import pytest
 
@@ -17,7 +19,7 @@ def test_varlocation():
     # number of point and cell data.
     writer = meshio.tecplot.write
     reader = meshio.tecplot.read
-    mesh = helpers.tri_mesh
+    mesh = deepcopy(helpers.tri_mesh)
     num_points = len(mesh.points)
     num_cells = sum(len(c.data) for c in mesh.cells)
 


### PR DESCRIPTION
**Writer**
- Fixed: ``VARLOCATION`` was not written if mesh contains only one cell data.

**Test**
- Added: test that ``VARLOCATION`` is correctly read and written for any number of point and cell data.