### PR TITLE
read cell_sets from Gmsh MSH 4.1

### DIFF
--- a/meshio/_mesh.py
+++ b/meshio/_mesh.py
@@ -144,6 +144,32 @@ class Mesh:
                 cell_data_dict[key][cell_type] = numpy.concatenate(val)
         return cell_data_dict
 
+    @property
+    def cell_sets_dict(self):
+        sets_dict = {}
+        for key, member_list in self.cell_sets.items():
+            sets_dict[key] = {}
+            offsets = {}
+            for members, cells in zip(member_list, self.cells):
+                if cells.type in offsets:
+                    offset = offsets[cells.type]
+                    offsets[cells.type] += cells.data.shape[0]
+                else:
+                    offset = 0
+                    offsets[cells.type] = cells.data.shape[0]
+                if cells.type in sets_dict[key]:
+                    sets_dict[key][cells.type].append(members + offset)
+                else:
+                    sets_dict[key][cells.type] = [members + offset]
+        return {
+            key: {
+                cell_type: numpy.concatenate(members)
+                for cell_type, members in sets.items()
+                if sum(map(numpy.size, members))
+            }
+            for key, sets in sets_dict.items()
+        }
+
     @classmethod
     def read(cls, path_or_buf, file_format=None):
         # avoid circular import

--- a/test/test_gmsh.py
+++ b/test/test_gmsh.py
@@ -137,19 +137,19 @@ def test_reference_file(filename, ref_sum, ref_num_cells, binary):
     helpers.write_read(writer, meshio.gmsh.read, mesh, 1.0e-15)
 
 
-# @pytest.mark.parametrize(
-#     "filename, ref_sum, ref_num_cells",
-#     [("insulated-4.1.msh", 2.001762136876221, {"line": 21, "triangle": 111})],
-# )
-# def test_reference_file_readonly(filename, ref_sum, ref_num_cells):
-#     this_dir = os.path.dirname(os.path.abspath(__file__))
-#     filename = os.path.join(this_dir, "meshes", "msh", filename)
-#
-#     mesh = meshio.read(filename)
-#     tol = 1.0e-2
-#     s = mesh.points.sum()
-#     assert abs(s - ref_sum) < tol * ref_sum
-#     assert {k: len(v) for k, v in mesh.cells.items()} == ref_num_cells
-#     assert {
-#         k: len(v["gmsh:physical"]) for k, v in mesh.cell_data.items()
-#     } == ref_num_cells
+@pytest.mark.parametrize(
+    "filename, ref_sum, ref_num_cells",
+    [("insulated-4.1.msh", 2.001762136876221, {"line": 21, "triangle": 111})],
+)
+def test_reference_file_readonly(filename, ref_sum, ref_num_cells):
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    filename = os.path.join(this_dir, "meshes", "msh", filename)
+
+    mesh = meshio.read(filename)
+    tol = 1.0e-2
+    s = mesh.points.sum()
+    assert abs(s - ref_sum) < tol * ref_sum
+    assert {k: len(v) for k, v in mesh.cells_dict.items()} == ref_num_cells
+    assert {
+        k: len(v) for k, v in mesh.cell_data_dict["gmsh:physical"].items()
+    } == ref_num_cells

--- a/test/test_gmsh.py
+++ b/test/test_gmsh.py
@@ -153,3 +153,9 @@ def test_reference_file_readonly(filename, ref_sum, ref_num_cells):
     assert {
         k: len(v) for k, v in mesh.cell_data_dict["gmsh:physical"].items()
     } == ref_num_cells
+
+    num_cells = {k: 0 for k in ref_num_cells}
+    for vv in mesh.cell_sets_dict.values():
+        for k, v in vv.items():
+            num_cells[k] += len(v)
+    assert num_cells == ref_num_cells


### PR DESCRIPTION
Fixes #698, fixes #700.

With this, Gmsh's MSH 4.1 becomes the second file format after Abaqus to populate `meshio.Mesh.cell_sets` on reading.

To begin with, it just does this, it doesn't change any of the previous behaviour; the first physical tag is still stored `.cell_data["gmsh:physical"]`.  I think that this inadequate behaviour (discarding possible subsequent physical tags) should be deprecated; it is currently relied upon downstream, e.g.

https://github.com/kinnala/scikit-fem/blob/110f7a230528b6f0aa8b0a17aae69d8ebc1b5355/skfem/io/meshio.py#L78