### PR TITLE
Use precision 17 for the output mesh (Abaqus)

### DIFF
--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -277,7 +277,7 @@ def write(filename, mesh, translate_cell_names=True):
         f.write("Abaqus DataFile Version 6.14\n")
         f.write("written by meshio v{}\n".format(__version__))
         f.write("*Node\n")
-        fmt = ", ".join(["{}"] + ["{!r}"] * mesh.points.shape[1]) + "\n"
+        fmt = ", ".join(["{}"] + ["{:.17g}"] * mesh.points.shape[1]) + "\n"
         for k, x in enumerate(mesh.points):
             f.write(fmt.format(k + 1, *x))
         eid = 0


### PR DESCRIPTION
When writing to a file format in ASCII, the floating-point numbers are rounded.

By default, it seems meshio uses 6 digits of precision to write `double` numbers. Setting the precision to 17 digits guarantees that converting from binary `double` to decimals, and then back to binary `double` will be exact. That is the [definition of `DBL_DECIMAL_DIG` (C11/C++17)](https://en.cppreference.com/w/c/types/limits):
> this is the decimal precision required to serialize/deserialize a floating-point value

This PR only modifies the Abaqus output, because that was the output I needed, and I have tested. Maybe that should be configurable, and generalized for the other ASCII outputs.

Cc: @sloriot
