### PR TITLE
Replace ModuleNotFoundError by ImportError

### DIFF
--- a/meshio/cgns/_cgns.py
+++ b/meshio/cgns/_cgns.py
@@ -89,6 +89,7 @@ def write(filename, mesh, compression="gzip", compression_opts=4):
 
 try:
     import h5py
+# Use ModuleNotFoundError when dropping support for Python 3.5
 except ImportError:
     pass
 else:

--- a/meshio/cgns/_cgns.py
+++ b/meshio/cgns/_cgns.py
@@ -89,7 +89,7 @@ def write(filename, mesh, compression="gzip", compression_opts=4):
 
 try:
     import h5py
-except ModuleNotFoundError:
+except ImportError:
     pass
 else:
     register("cgns", [".cgns"], read, {"cgns": write})

--- a/meshio/exodus/_exodus.py
+++ b/meshio/exodus/_exodus.py
@@ -370,6 +370,7 @@ def write(filename, mesh):
 
 try:
     import netCDF4
+# Use ModuleNotFoundError when dropping support for Python 3.5
 except ImportError:
     pass
 else:

--- a/meshio/exodus/_exodus.py
+++ b/meshio/exodus/_exodus.py
@@ -370,7 +370,7 @@ def write(filename, mesh):
 
 try:
     import netCDF4
-except ModuleNotFoundError:
+except ImportError:
     pass
 else:
     register("exodus", [".e", ".exo", ".ex2"], read, {"exodus": write})

--- a/meshio/h5m/_h5m.py
+++ b/meshio/h5m/_h5m.py
@@ -269,6 +269,7 @@ def write(filename, mesh, add_global_ids=True, compression="gzip", compression_o
 
 try:
     import h5py
+# Use ModuleNotFoundError when dropping support for Python 3.5
 except ImportError:
     pass
 else:

--- a/meshio/h5m/_h5m.py
+++ b/meshio/h5m/_h5m.py
@@ -269,7 +269,7 @@ def write(filename, mesh, add_global_ids=True, compression="gzip", compression_o
 
 try:
     import h5py
-except ModuleNotFoundError:
+except ImportError:
     pass
 else:
     register("h5m", [".h5m"], read, {"h5m": write})

--- a/meshio/med/_med.py
+++ b/meshio/med/_med.py
@@ -466,6 +466,7 @@ def _write_families(fm_group, tags, compression, compression_opts):
 
 try:
     import h5py
+# Use ModuleNotFoundError when dropping support for Python 3.5
 except ImportError:
     pass
 else:

--- a/meshio/med/_med.py
+++ b/meshio/med/_med.py
@@ -466,7 +466,7 @@ def _write_families(fm_group, tags, compression, compression_opts):
 
 try:
     import h5py
-except ModuleNotFoundError:
+except ImportError:
     pass
 else:
     register("med", [".med"], read, {"med": write})

--- a/meshio/xdmf/main.py
+++ b/meshio/xdmf/main.py
@@ -520,7 +520,7 @@ def write(*args, **kwargs):
 
 try:
     import h5py
-except ModuleNotFoundError:
+except ImportError:
     pass
 else:
     # TODO register all xdmf except hdf outside this try block

--- a/meshio/xdmf/main.py
+++ b/meshio/xdmf/main.py
@@ -520,6 +520,7 @@ def write(*args, **kwargs):
 
 try:
     import h5py
+# Use ModuleNotFoundError when dropping support for Python 3.5
 except ImportError:
     pass
 else:


### PR DESCRIPTION
- Fixed: ``ModuleNotFoundError`` is only available in ``python>=3.6``.