### PR TITLE
Read and write info from/to vtk, medit, xdmf

### DIFF
--- a/meshio/medit/_medit.py
+++ b/meshio/medit/_medit.py
@@ -30,6 +30,7 @@ def read_buffer(f):
     cells = []
     point_data = {}
     cell_data = {"medit:ref": []}
+    spec_info = []
 
     meshio_from_medit = {
         "Edges": ("line", 2),
@@ -47,7 +48,10 @@ def read_buffer(f):
             break
 
         line = line.strip()
-        if len(line) == 0 or line[0] == "#":
+        if len(line) == 0:
+            continue
+        if line[0] == "#":
+            spec_info.append(line[1:])
             continue
 
         items = line.split()
@@ -97,7 +101,9 @@ def read_buffer(f):
             if items[0] != "End":
                 raise ReadError("Unknown keyword '{}'.".format(items[0]))
 
-    return Mesh(points, cells, point_data=point_data, cell_data=cell_data)
+    return Mesh(
+        points, cells, point_data=point_data, cell_data=cell_data, info=spec_info,
+    )
 
 
 def write(filename, mesh, float_fmt=".15e"):

--- a/meshio/medit/_medit.py
+++ b/meshio/medit/_medit.py
@@ -106,8 +106,12 @@ def read_buffer(f):
     )
 
 
-def write(filename, mesh, float_fmt=".15e"):
+def write(filename, mesh, float_fmt=".15e", info=None):
     with open_file(filename, "wb") as fh:
+        # write specific information as comments
+        if info:
+            fh.write(bytes("".join("# %s\n" % i for i in info), "utf-8"))
+
         version = {numpy.dtype(c_float): 1, numpy.dtype(c_double): 2}[mesh.points.dtype]
         # N. B.: PEP 461 Adding % formatting to bytes and bytearray
         fh.write(b"MeshVersionFormatted %d\n" % version)

--- a/meshio/vtk/_vtk.py
+++ b/meshio/vtk/_vtk.py
@@ -148,7 +148,7 @@ def read_buffer(f):
 
     # skip header and title
     f.readline()
-    f.readline()
+    spec_info = [f.readline().decode("utf-8")]
 
     data_type = f.readline().decode("utf-8").strip().upper()
     if data_type not in ["ASCII", "BINARY"]:
@@ -182,6 +182,7 @@ def read_buffer(f):
         point_data=info.point_data,
         cell_data=cell_data,
         field_data=info.field_data,
+        info=spec_info,
     )
 
 

--- a/meshio/vtk/_vtk.py
+++ b/meshio/vtk/_vtk.py
@@ -582,7 +582,7 @@ def translate_cells(data, types, cell_data_raw):
     return cells, cell_data
 
 
-def write(filename, mesh, binary=True):
+def write(filename, mesh, binary=True, info=None):
     def pad(array):
         return numpy.pad(array, ((0, 0), (0, 1)), "constant")
 
@@ -617,8 +617,14 @@ def write(filename, mesh, binary=True):
         logging.warning("VTK ASCII files are only meant for debugging.")
 
     with open_file(filename, "wb") as f:
+        if info is not None and len(info) > 0:
+            # first item in info truncated to 255 characters + '\n'
+            info_line = "{}\n".format(info[0] if len(info[0]) < 256 else info[0][:255])
+        else:
+            info_line = "written by meshio v{}\n".format(__version__)
+
         f.write(b"# vtk DataFile Version 4.2\n")
-        f.write("written by meshio v{}\n".format(__version__).encode("utf-8"))
+        f.write(info_line.encode("utf-8"))
         f.write(("BINARY\n" if binary else "ASCII\n").encode("utf-8"))
         f.write(b"DATASET UNSTRUCTURED_GRID\n")
 

--- a/meshio/xdmf/main.py
+++ b/meshio/xdmf/main.py
@@ -123,19 +123,15 @@ class XdmfReader:
         return field_data
 
     def read_xdmf2(self, root):  # noqa: C901
-        domains = list(root)
+        domains = root.findall("Domain")
         if len(domains) != 1:
             raise ReadError()
         domain = domains[0]
-        if domain.tag != "Domain":
-            raise ReadError()
 
-        grids = list(domain)
+        grids = domain.findall("Grid")
         if len(grids) != 1:
             raise ReadError("XDMF reader: Only supports one grid right now.")
         grid = grids[0]
-        if grid.tag != "Grid":
-            raise ReadError()
 
         if grid.get("GridType") not in (None, "Uniform"):
             raise ReadError()
@@ -203,28 +199,27 @@ class XdmfReader:
 
         cell_data = cell_data_from_raw(cells, cell_data_raw)
 
+        spec_info = [ii.text for ii in root.iter("Information")]
+
         return Mesh(
             points,
             cells,
             point_data=point_data,
             cell_data=cell_data,
             field_data=field_data,
+            info=spec_info,
         )
 
     def read_xdmf3(self, root):  # noqa: C901
-        domains = list(root)
+        domains = root.findall("Domain")
         if len(domains) != 1:
             raise ReadError()
         domain = domains[0]
-        if domain.tag != "Domain":
-            raise ReadError()
 
-        grids = list(domain)
+        grids = domain.findall("Grid")
         if len(grids) != 1:
             raise ReadError("XDMF reader: Only supports one grid right now.")
         grid = grids[0]
-        if grid.tag != "Grid":
-            raise ReadError()
 
         points = None
         cells = []
@@ -302,12 +297,15 @@ class XdmfReader:
 
         cell_data = cell_data_from_raw(cells, cell_data_raw)
 
+        spec_info = [ii.text for ii in root.iter("Information")]
+
         return Mesh(
             points,
             cells,
             point_data=point_data,
             cell_data=cell_data,
             field_data=field_data,
+            info=spec_info,
         )
 
 

--- a/meshio/xdmf/main.py
+++ b/meshio/xdmf/main.py
@@ -311,7 +311,13 @@ class XdmfReader:
 
 class XdmfWriter:
     def __init__(
-        self, filename, mesh, data_format="HDF", compression="gzip", compression_opts=4
+        self,
+        filename,
+        mesh,
+        data_format="HDF",
+        compression="gzip",
+        compression_opts=4,
+        info=None,
     ):
         if data_format not in ["XML", "Binary", "HDF"]:
             raise WriteError(
@@ -330,6 +336,10 @@ class XdmfWriter:
             self.h5_file = h5py.File(self.h5_filename, "w")
 
         xdmf_file = ET.Element("Xdmf", Version="3.0")
+
+        if info:
+            for i in info:
+                ET.SubElement(xdmf_file, "Information", Value=i)
 
         domain = ET.SubElement(xdmf_file, "Domain")
         grid = ET.SubElement(domain, "Grid", Name="Grid")

--- a/meshio/xdmf/time_series.py
+++ b/meshio/xdmf/time_series.py
@@ -229,7 +229,7 @@ class TimeSeriesReader:
 
 
 class TimeSeriesWriter:
-    def __init__(self, filename, data_format="HDF"):
+    def __init__(self, filename, data_format="HDF", info=None):
         if data_format not in ["XML", "Binary", "HDF"]:
             raise WriteError(
                 "Unknown XDMF data format "
@@ -241,6 +241,10 @@ class TimeSeriesWriter:
         self.data_counter = 0
 
         self.xdmf_file = ET.Element("Xdmf", Version="3.0")
+
+        if info:
+            for i in info:
+                ET.SubElement(self.xdmf_file, "Information", Value=i)
 
         self.domain = ET.SubElement(self.xdmf_file, "Domain")
         self.collection = ET.SubElement(

--- a/meshio/xdmf/time_series.py
+++ b/meshio/xdmf/time_series.py
@@ -35,14 +35,14 @@ class TimeSeriesReader:
         if version.split(".")[0] != "3":
             raise ReadError("Unknown XDMF version {}.".format(version))
 
-        domains = list(root)
+        self.info = [ii.text for ii in root.iter("Information")]
+
+        domains = root.findall("Domain")
         if len(domains) != 1:
             raise ReadError()
         self.domain = domains[0]
-        if self.domain.tag != "Domain":
-            raise ReadError()
 
-        grids = list(self.domain)
+        grids = self.domain.findall("Grid")
 
         # find the collection grid
         collection_grid = None
@@ -57,7 +57,7 @@ class TimeSeriesReader:
             raise ReadError()
 
         # get the collection at once
-        self.collection = list(collection_grid)
+        self.collection = collection_grid.findall("Grid")
         self.num_steps = len(self.collection)
         self.cells = None
         self.hdf5_files = {}


### PR DESCRIPTION
This PR allows to read and write application specific information (e.g. bounds, post-processing data, time steps, etc.) in VTK, MEDIT and XDMF formats.

The information is stored in:
- VTK: title line
- MEDIT: comment line
- XDMF: `Information` tag