### PR TITLE
Fixing polyline visualization

### DIFF
--- a/meshio/xdmf/main.py
+++ b/meshio/xdmf/main.py
@@ -410,6 +410,7 @@ class XdmfWriter:
                 "Topology",
                 TopologyType=xdmf_type,
                 NumberOfElements=str(num_cells),
+                NodesPerElement=str(cells[0].data.shape[1])
             )
             dt, prec = numpy_to_xdmf_dtype[cells[0].data.dtype.name]
             dim = "{} {}".format(*cells[0].data.shape)

--- a/meshio/xdmf/main.py
+++ b/meshio/xdmf/main.py
@@ -410,7 +410,7 @@ class XdmfWriter:
                 "Topology",
                 TopologyType=xdmf_type,
                 NumberOfElements=str(num_cells),
-                NodesPerElement=str(cells[0].data.shape[1])
+                NodesPerElement=str(cells[0].data.shape[1]),
             )
             dt, prec = numpy_to_xdmf_dtype[cells[0].data.dtype.name]
             dim = "{} {}".format(*cells[0].data.shape)


### PR DESCRIPTION
Given a simplistic mesh:
```
$MeshFormat
4.1 0 8
$EndMeshFormat
$Entities
4 4 1 0
6 0 0 0 0 
7 2 0 0 0 
8 0 2 0 0 
9 2 2 0 0 
10 0 0 0 2 0 0 1 3 2 6 -7 
20 2 0 0 2 2 0 1 2 2 7 -9 
30 0 2 0 2 2 0 1 4 2 9 -8 
40 0 0 0 0 2 0 1 1 2 8 -6 
1 0 0 0 2 2 0 1 0 4 10 20 30 40 
$EndEntities
$Nodes
9 13 1 13
0 6 0 1
1
0 0 0
0 7 0 1
2
2 0 0
0 8 0 1
3
0 2 0
0 9 0 1
4
2 2 0
1 10 0 1
5
0.999999999997388 0 0
1 20 0 1
6
2 0.999999999997388 0
1 30 0 1
7
1.000000000004118 2 0
1 40 0 1
8
0 1.000000000004118 0
2 1 0 5
9
10
11
12
13
1.000000000000282 1.000000000000376 0
0.500000000002059 1.500000000002059 0
1.5000000000011 1.499999999999441 0
1.499999999999418 0.4999999999994411 0
0.4999999999994176 0.5000000000011235 0
$EndNodes
$Elements
5 24 1 24
1 10 1 2
1 1 5 
2 5 2 
1 20 1 2
3 2 6 
4 6 4 
1 30 1 2
5 4 7 
6 7 3 
1 40 1 2
7 3 8 
8 8 1 
2 1 2 16
9 7 3 10 
10 8 1 13 
11 6 4 11 
12 5 2 12 
13 9 7 10 
14 8 9 10 
15 7 9 11 
16 9 8 13 
17 9 6 11 
18 5 9 13 
19 9 5 12 
20 6 9 12 
21 1 5 13 
22 2 6 12 
23 3 8 10 
24 4 7 11 
$EndElements
``` 
the following meshio code runs:
```
import meshio
import numpy as np
msh = meshio.read("mesh.msh")

line_cells = np.vstack([cells.data for cells in msh.cells
                                 if cells.type == "line"])
line_data = np.vstack([msh.cell_data_dict["gmsh:physical"][key] for key in msh.cell_data_dict["gmsh:physical"].keys() if key == "line"])


triangle_cells = np.vstack([cells.data for cells in msh.cells
                            if cells.type == "triangle"])
triangle_data = np.vstack([msh.cell_data_dict["gmsh:physical"][key] for key in msh.cell_data_dict["gmsh:physical"].keys() if key == "triangle"])


line_mesh =meshio.Mesh(points=msh.points,
                           cells=[("line", line_cells)],
                           cell_data={"name_to_read":line_data})

triangle_mesh =meshio.Mesh(points=msh.points,
                           cells=[("triangle", triangle_cells)],
                           cell_data={"name_to_read":triangle_data})

meshio.write("mesh.xdmf", triangle_mesh, data_format="XML")

meshio.xdmf.write("mf.xdmf", line_mesh, data_format="XML")

```
but causes Paraview 5.7 to crash when trying to open `mf.xdmf` due to lack of NodesPerElement in topology.