### PR TITLE
Mesh comments

### DIFF
--- a/meshio/_helpers.py
+++ b/meshio/_helpers.py
@@ -141,9 +141,12 @@ def write(filename, mesh, file_format=None, **kwargs):
             # cannot check those
             pass
 
+    comment = "This file was created by meshio v{}".format(__version__)
     if mesh.comments is None or len(mesh.comments) == 0:
-        comment = "This file was created by meshio v{}".format(__version__)
         mesh.comments = [comment]
+    else:
+        if mesh.comments[-1] != comment:
+            mesh.comments.append(comment)
 
     # Write
     return writer(filename, mesh, **kwargs)

--- a/meshio/_helpers.py
+++ b/meshio/_helpers.py
@@ -2,6 +2,7 @@ import pathlib
 
 import numpy
 
+from .__about__ import __version__
 from ._common import num_nodes_per_cell
 from ._exceptions import ReadError, WriteError
 from ._files import is_buffer
@@ -139,6 +140,10 @@ def write(filename, mesh, file_format=None, **kwargs):
             # we allow custom keys <https://github.com/nschloe/meshio/issues/501> and
             # cannot check those
             pass
+
+    if mesh.comments is None or len(mesh.comments) == 0:
+        comment = "This file was created by meshio v{}".format(__version__)
+        mesh.comments = [comment]
 
     # Write
     return writer(filename, mesh, **kwargs)

--- a/meshio/_mesh.py
+++ b/meshio/_mesh.py
@@ -17,6 +17,7 @@ class Mesh:
         cell_sets=None,
         gmsh_periodic=None,
         info=None,
+        comments=None,
     ):
         self.points = points
         if isinstance(cells, dict):
@@ -40,6 +41,7 @@ class Mesh:
         self.cell_sets = {} if cell_sets is None else cell_sets
         self.gmsh_periodic = gmsh_periodic
         self.info = info
+        self.comments = comments
 
     def __repr__(self):
         lines = [

--- a/meshio/medit/_medit.py
+++ b/meshio/medit/_medit.py
@@ -30,6 +30,7 @@ def read_buffer(f):
     cells = []
     point_data = {}
     cell_data = {"medit:ref": []}
+    comments = []
 
     meshio_from_medit = {
         "Edges": ("line", 2),
@@ -47,7 +48,10 @@ def read_buffer(f):
             break
 
         line = line.strip()
-        if len(line) == 0 or line[0] == "#":
+        if len(line) == 0:
+            continue
+        if line[0] == "#":
+            comments.append(line[1:].strip())
             continue
 
         items = line.split()
@@ -97,7 +101,9 @@ def read_buffer(f):
             if items[0] != "End":
                 raise ReadError("Unknown keyword '{}'.".format(items[0]))
 
-    return Mesh(points, cells, point_data=point_data, cell_data=cell_data)
+    return Mesh(
+        points, cells, point_data=point_data, cell_data=cell_data, comments=comments,
+    )
 
 
 def write(filename, mesh, float_fmt=".15e"):

--- a/meshio/medit/_medit.py
+++ b/meshio/medit/_medit.py
@@ -108,6 +108,10 @@ def read_buffer(f):
 
 def write(filename, mesh, float_fmt=".15e"):
     with open_file(filename, "wb") as fh:
+        if mesh.comments:
+            for c in mesh.comments:
+                fh.write("# {}\n".format(c).encode("utf-8"))
+
         version = {numpy.dtype(c_float): 1, numpy.dtype(c_double): 2}[mesh.points.dtype]
         # N. B.: PEP 461 Adding % formatting to bytes and bytearray
         fh.write(b"MeshVersionFormatted %d\n" % version)

--- a/meshio/tetgen/_tetgen.py
+++ b/meshio/tetgen/_tetgen.py
@@ -24,10 +24,13 @@ def read(filename):
     else:
         raise ReadError()
 
+    comments = []
     # read nodes
     with open(node_filename) as f:
         line = f.readline().strip()
         while len(line) == 0 or line[0] == "#":
+            if line[0] == "#":
+                comments.append(line[1:].strip())
             line = f.readline().strip()
 
         num_points, dim, num_attrs, num_bmarkers = [
@@ -54,6 +57,8 @@ def read(filename):
     with open(ele_filename) as f:
         line = f.readline().strip()
         while len(line) == 0 or line[0] == "#":
+            if line[0] == "#":
+                comments.append(line[1:].strip())
             line = f.readline().strip()
 
         num_tets, num_points_per_tet, num_attrs = [
@@ -68,7 +73,7 @@ def read(filename):
         cells = cells[:, 1:5]
         cells -= node_index_base
 
-    return Mesh(points, [CellBlock("tetra", cells)])
+    return Mesh(points, [CellBlock("tetra", cells)], comments=comments)
 
 
 def write(filename, mesh, float_fmt=".15e"):

--- a/meshio/tetgen/_tetgen.py
+++ b/meshio/tetgen/_tetgen.py
@@ -7,7 +7,6 @@ import os
 
 import numpy
 
-from ..__about__ import __version__
 from .._exceptions import ReadError, WriteError
 from .._helpers import register
 from .._mesh import CellBlock, Mesh
@@ -92,7 +91,9 @@ def write(filename, mesh, float_fmt=".15e"):
 
     # write nodes
     with open(node_filename, "w") as fh:
-        fh.write("# This file was created by meshio v{}\n".format(__version__))
+        if mesh.comments:
+            for c in mesh.comments:
+                fh.write("# {}\n".format(c))
         fh.write("{} {} {} {}\n".format(mesh.points.shape[0], 3, 0, 0))
         fmt = "{} " + " ".join(3 * ["{:" + float_fmt + "}"]) + "\n"
         for k, pt in enumerate(mesh.points):
@@ -110,7 +111,9 @@ def write(filename, mesh, float_fmt=".15e"):
 
     # write cells
     with open(ele_filename, "w") as fh:
-        fh.write("# This file was created by meshio v{}\n".format(__version__))
+        if mesh.comments:
+            for c in mesh.comments:
+                fh.write("# {}\n".format(c))
         for cell_type, data in filter(lambda c: c.type == "tetra", mesh.cells):
             fh.write("{} {} {}\n".format(data.shape[0], 4, 0))
             for k, tet in enumerate(data):

--- a/meshio/vtk/_vtk.py
+++ b/meshio/vtk/_vtk.py
@@ -146,9 +146,10 @@ def read_buffer(f):
     # initialize output data
     info = Info()
 
-    # skip header and title
+    # skip header
     f.readline()
-    f.readline()
+    # read title
+    comments = [k.strip() for k in f.readline().decode("utf-8").split(";")]
 
     data_type = f.readline().decode("utf-8").strip().upper()
     if data_type not in ["ASCII", "BINARY"]:
@@ -182,6 +183,7 @@ def read_buffer(f):
         point_data=info.point_data,
         cell_data=cell_data,
         field_data=info.field_data,
+        comments=comments,
     )
 
 

--- a/meshio/vtk/_vtk.py
+++ b/meshio/vtk/_vtk.py
@@ -6,7 +6,6 @@ from functools import reduce
 
 import numpy
 
-from ..__about__ import __version__
 from .._common import meshio_to_vtk_type, vtk_to_meshio_type
 from .._exceptions import ReadError, WriteError
 from .._files import open_file
@@ -618,8 +617,20 @@ def write(filename, mesh, binary=True):
         logging.warning("VTK ASCII files are only meant for debugging.")
 
     with open_file(filename, "wb") as f:
+        if mesh.comments is not None and len(mesh.comments) > 0:
+            comments = "; ".join(mesh.comments)
+            if len(comments) < 256:
+                title_line = "{}\n".format(comments)
+            else:
+                title_line = "{}\n".format(comments[:255])
+                logging.warning(
+                    "Comments are too long. Writing only the first 255 characters."
+                )
+        else:
+            title_line = "\n"
+
         f.write(b"# vtk DataFile Version 4.2\n")
-        f.write("written by meshio v{}\n".format(__version__).encode("utf-8"))
+        f.write(title_line.encode("utf-8"))
         f.write(("BINARY\n" if binary else "ASCII\n").encode("utf-8"))
         f.write(b"DATASET UNSTRUCTURED_GRID\n")
 

--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -11,7 +11,6 @@ import zlib
 
 import numpy
 
-from ..__about__ import __version__
 from .._common import (
     meshio_to_vtk_type,
     num_nodes_per_cell,
@@ -503,7 +502,12 @@ def write(filename, mesh, binary=True, compression="zlib", header_type=None):
         da.text_writer = text_writer
         return
 
-    comment = ET.Comment("This file was created by meshio v{}".format(__version__))
+    if mesh.comments is not None and len(mesh.comments) > 0:
+        comments = "\n".join(mesh.comments)
+    else:
+        comments = ""
+
+    comment = ET.Comment(comments)
     vtk_file.insert(1, comment)
 
     grid = ET.SubElement(vtk_file, "UnstructuredGrid")

--- a/meshio/xdmf/common.py
+++ b/meshio/xdmf/common.py
@@ -171,3 +171,18 @@ def attribute_type(data):
     if len(data.shape) != 3:
         raise ReadError()
     return "Matrix"
+
+
+def read_comments(root):
+    comments = []
+    for ii in root.iter("Information"):
+        comment = ""
+        if "Name" in ii.attrib:
+            comment += ii.attrib["Name"] + "::"
+        if "Value" in ii.attrib:
+            comment += ii.attrib["Value"].strip()
+        else:
+            comment += ii.text.strip()
+        comments.append(comment)
+
+    return comments

--- a/meshio/xdmf/common.py
+++ b/meshio/xdmf/common.py
@@ -1,3 +1,5 @@
+import xml.etree.ElementTree as ET
+
 import numpy
 
 from .._exceptions import ReadError
@@ -186,3 +188,16 @@ def read_comments(root):
         comments.append(comment)
 
     return comments
+
+
+def write_comments(xdmf_file, comments):
+    if comments:
+        for c in comments:
+            if "::" in c:
+                name, val = c.split("::", maxsplit=1)
+                comment = ET.SubElement(xdmf_file, "Information", Name=name)
+            else:
+                val = c
+                comment = ET.SubElement(xdmf_file, "Information")
+
+            comment.text = val

--- a/meshio/xdmf/main.py
+++ b/meshio/xdmf/main.py
@@ -18,6 +18,7 @@ from .common import (
     meshio_to_xdmf_type,
     meshio_type_to_xdmf_index,
     numpy_to_xdmf_dtype,
+    read_comments,
     translate_mixed_cells,
     xdmf_to_meshio_type,
     xdmf_to_numpy_type,
@@ -125,19 +126,15 @@ class XdmfReader:
         return field_data
 
     def read_xdmf2(self, root):  # noqa: C901
-        domains = list(root)
+        domains = root.findall("Domain")
         if len(domains) != 1:
             raise ReadError()
         domain = domains[0]
-        if domain.tag != "Domain":
-            raise ReadError()
 
-        grids = list(domain)
+        grids = domain.findall("Grid")
         if len(grids) != 1:
             raise ReadError("XDMF reader: Only supports one grid right now.")
         grid = grids[0]
-        if grid.tag != "Grid":
-            raise ReadError()
 
         if grid.get("GridType") not in (None, "Uniform"):
             raise ReadError()
@@ -150,7 +147,7 @@ class XdmfReader:
 
         for c in grid:
             if c.tag == "Topology":
-                data_items = list(c)
+                data_items = c.findall("DataItem")
                 if len(data_items) != 1:
                     raise ReadError()
                 topology_type = c.get("TopologyType")
@@ -170,7 +167,7 @@ class XdmfReader:
             elif c.tag == "Geometry":
                 if c.get("GeometryType") not in (None, "XYZ"):
                     raise ReadError()
-                data_items = list(c)
+                data_items = c.findall("DataItem")
                 if len(data_items) != 1:
                     raise ReadError()
                 points = self._read_data_item(data_items[0])
@@ -185,7 +182,7 @@ class XdmfReader:
                 # assert c.attrib['Active'] == '1'
                 # assert c.attrib['AttributeType'] == 'None'
 
-                data_items = list(c)
+                data_items = c.findall("DataItem")
                 if len(data_items) != 1:
                     raise ReadError()
 
@@ -211,22 +208,19 @@ class XdmfReader:
             point_data=point_data,
             cell_data=cell_data,
             field_data=field_data,
+            comments=read_comments(root),
         )
 
     def read_xdmf3(self, root):  # noqa: C901
-        domains = list(root)
+        domains = root.findall("Domain")
         if len(domains) != 1:
             raise ReadError()
         domain = domains[0]
-        if domain.tag != "Domain":
-            raise ReadError()
 
-        grids = list(domain)
+        grids = domain.findall("Grid")
         if len(grids) != 1:
             raise ReadError("XDMF reader: Only supports one grid right now.")
         grid = grids[0]
-        if grid.tag != "Grid":
-            raise ReadError()
 
         points = None
         cells = []
@@ -236,7 +230,7 @@ class XdmfReader:
 
         for c in grid:
             if c.tag == "Topology":
-                data_items = list(c)
+                data_items = c.findall("DataItem")
                 if len(data_items) != 1:
                     raise ReadError()
                 data_item = data_items[0]
@@ -268,7 +262,7 @@ class XdmfReader:
                 if geometry_type not in ["XY", "XYZ"]:
                     raise ReadError('Illegal geometry type "{}".'.format(geometry_type))
 
-                data_items = list(c)
+                data_items = c.findall("DataItem")
                 if len(data_items) != 1:
                     raise ReadError()
                 data_item = data_items[0]
@@ -285,7 +279,7 @@ class XdmfReader:
                 # 'AttributeType'.
                 # assert c.attrib['Type'] == 'None'
 
-                data_items = list(c)
+                data_items = c.findall("DataItem")
                 if len(data_items) != 1:
                     raise ReadError()
                 data_item = data_items[0]
@@ -310,6 +304,7 @@ class XdmfReader:
             point_data=point_data,
             cell_data=cell_data,
             field_data=field_data,
+            comments=read_comments(root),
         )
 
 

--- a/meshio/xdmf/main.py
+++ b/meshio/xdmf/main.py
@@ -20,6 +20,7 @@ from .common import (
     numpy_to_xdmf_dtype,
     read_comments,
     translate_mixed_cells,
+    write_comments,
     xdmf_to_meshio_type,
     xdmf_to_numpy_type,
 )
@@ -331,6 +332,8 @@ class XdmfWriter:
             self.h5_file = h5py.File(self.h5_filename, "w")
 
         xdmf_file = ET.Element("Xdmf", Version="3.0")
+
+        write_comments(xdmf_file, mesh.comments)
 
         domain = ET.SubElement(xdmf_file, "Domain")
         grid = ET.SubElement(domain, "Grid", Name="Grid")

--- a/meshio/xdmf/time_series.py
+++ b/meshio/xdmf/time_series.py
@@ -16,6 +16,7 @@ from .common import (
     numpy_to_xdmf_dtype,
     read_comments,
     translate_mixed_cells,
+    write_comments,
     xdmf_to_meshio_type,
     xdmf_to_numpy_type,
 )
@@ -242,6 +243,9 @@ class TimeSeriesWriter:
         self.data_counter = 0
 
         self.xdmf_file = ET.Element("Xdmf", Version="3.0")
+
+        if hasattr(self, "comments"):
+            write_comments(self.xdmf_file, self.comments)
 
         self.domain = ET.SubElement(self.xdmf_file, "Domain")
         self.collection = ET.SubElement(


### PR DESCRIPTION
The second attempt. This PR consists of three commits. The first one implements gathering of comment texts from the following mesh files:

* VTK - from title line, split into list items by `;`
* MEDIT - lines starting with `#`
* TETGEN - lines starting with `#`
* XDMF - `<information>` tags
* VTU - not implemented, I do not know how to read XML comments `<!--...-->` using `ElementTree`. Any idea?

The comments are stored in `mesh.comments` as a list of strings. XDMF information can be represented by `name`-`value` pairs, these are converted to `"name::value"` strings.

The second commit implements writing `mesh.comments` into:

* VTK - title line, list items are joined by `; `, and truncated to 255 chars if necessary (and warning issued) 
* VTU - mesh comments written to XML comments `<!--...-->`
* MEDIT - comments written as lines starting with `# `
* TETGEN - comments written as lines starting with `# `
* XDMF - comments written as `<information>` tags, `"name::value"` strings converted to `name`-`value` pairs

If `mesh.comments` is empty, `"This file was created by meshio"` is added.

The third commit appends `"This file was created by meshio"` message if it is not the last item in the list. This allows to preserve the "file history", e.g. `["This mesh was created by SfePy", "This file was created by meshio"]`. This is a question for discussion.