### PR TITLE
Tecplot reader: handle white space in zone title

### DIFF
--- a/meshio/tecplot/_tecplot.py
+++ b/meshio/tecplot/_tecplot.py
@@ -119,7 +119,7 @@ def read_buffer(f):
                     break
             line = " ".join(lines)
 
-            zone = _read_zone(line, variables)
+            zone = _read_zone(line)
             (
                 num_nodes,
                 num_cells,
@@ -192,10 +192,21 @@ def _read_variables(line):
     return variables
 
 
-def _read_zone(line, variables):
+def _read_zone(line):
     # Gather zone entries in a dict
     line = line[5:]
     zone = {}
+
+    # Look for zone title
+    ivar = line.find('"')
+
+    # If zone contains a title, process it and save the title
+    if ivar >= 0:
+        i1, i2 = ivar, ivar + line[ivar + 1 :].find('"') + 2
+        zone_title = line[i1 + 1 : i2 - 1]
+        line = line.replace(line[i1:i2], "PLACEHOLDER")
+    else:
+        zone_title = None
 
     # Look for VARLOCATION (problematic since it contains both ',' and '=')
     ivar = line.find("VARLOCATION")
@@ -224,6 +235,10 @@ def _read_zone(line, variables):
 
         zone[key] = zone_key_to_type[key](value)
         i += 1
+
+    # Add zone title to zone dict
+    if zone_title:
+        zone["T"] = zone_title
 
     return zone
 

--- a/test/meshes/tecplot/quad_zone_comma.tec
+++ b/test/meshes/tecplot/quad_zone_comma.tec
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03ba928a289644685f34064ee7d0e818bfd5250c5122aaad8ea69f064fd96bc4
-size 257
+oid sha256:ae9424d04278a0553f615740f487aabdb38c830c61766fc060bff2bf232879bc
+size 270

--- a/test/meshes/tecplot/quad_zone_space.tec
+++ b/test/meshes/tecplot/quad_zone_space.tec
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e14f561e5a652a4b90bd9f11127a6d5fdb7ff7720f5797fae42e4bb712691bed
-size 256
+oid sha256:b63aa5f735d1b1d435dea9a16efca56739d225afe1b577f7ecf16a5f1d31a061
+size 264


### PR DESCRIPTION
- Fixed: white spaces in zone title were not correctly handled,
- Changed: sample test files have been edited accordingly.