### PR TITLE
Fix Abaqus reader (issue #749)

### DIFF
--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -320,8 +320,8 @@ def write(filename, mesh, float_fmt=".15e", translate_cell_names=True):
                 f.write(str(eid) + "," + ",".join(nids_strs) + "\n")
 
         nnl = 8
+        offset = 0
         for ic in range(len(mesh.cells)):
-            offset = sum(len(c.data) for c in mesh.cells[:ic])
             for k, v in mesh.cell_sets.items():
                 if len(v[ic]) > 0:
                     els = [str(i + 1 + offset) for i in v[ic]]
@@ -332,6 +332,7 @@ def write(filename, mesh, float_fmt=".15e", translate_cell_names=True):
                         )
                         + "\n"
                     )
+            offset += len(mesh.cells[ic].data)
 
         for k, v in mesh.point_sets.items():
             nds = [str(i + 1) for i in v]

--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -321,15 +321,17 @@ def write(filename, mesh, float_fmt=".15e", translate_cell_names=True):
 
         nnl = 8
         for ic in range(len(mesh.cells)):
+            offset = sum(len(c.data) for c in mesh.cells[:ic])
             for k, v in mesh.cell_sets.items():
-                els = [str(i + 1) for i in v[ic]]
-                f.write("*ELSET, ELSET=%s\n" % k)
-                f.write(
-                    ",\n".join(
-                        ",".join(els[i : i + nnl]) for i in range(0, len(els), nnl)
+                if len(v[ic]) > 0:
+                    els = [str(i + 1 + offset) for i in v[ic]]
+                    f.write("*ELSET, ELSET=%s\n" % k)
+                    f.write(
+                        ",\n".join(
+                            ",".join(els[i : i + nnl]) for i in range(0, len(els), nnl)
+                        )
+                        + "\n"
                     )
-                    + "\n"
-                )
 
         for k, v in mesh.point_sets.items():
             nds = [str(i + 1) for i in v]

--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -106,6 +106,8 @@ def read_buffer(f):
     cell_ids = []
     point_sets = {}
     cell_sets = {}
+    cell_sets_element = {}  # Handle cell sets defined in ELEMENT
+    cell_sets_element_order = []  # Order of keys is not preserved in Python 3.5
     field_data = {}
     cell_data = {}
     point_data = {}
@@ -124,9 +126,12 @@ def read_buffer(f):
         if keyword == "NODE":
             points, point_ids, line = _read_nodes(f)
         elif keyword == "ELEMENT":
-            cell_type, cells_data, ids, line = _read_cells(f, line, point_ids)
+            cell_type, cells_data, ids, sets, line = _read_cells(f, line, point_ids)
             cells.append(CellBlock(cell_type, cells_data))
             cell_ids.append(ids)
+            if sets:
+                cell_sets_element.update(sets)
+                cell_sets_element_order += list(sets.keys())
         elif keyword == "NSET":
             params_map = get_param_map(line, required_keys=["NSET"])
             set_ids, line = _read_set(f, params_map)
@@ -148,6 +153,20 @@ def read_buffer(f):
         else:
             # There are just too many Abaqus keywords to explicitly skip them.
             line = f.readline()
+
+    # Parse cell sets defined in ELEMENT
+    for i, name in enumerate(cell_sets_element_order):
+        # Not sure whether this case would ever happen
+        if name in cell_sets.keys():
+            cell_sets[name][i] = cell_sets_element[name]
+        else:
+            cell_sets[name] = []
+            for ic in range(len(cells)):
+                cell_sets[name].append(
+                    cell_sets_element[name]
+                    if i == ic
+                    else numpy.array([], dtype="int32")
+                )
 
     return Mesh(
         points,
@@ -212,7 +231,14 @@ def _read_cells(f, line0, point_ids):
             cells.append([point_ids[k] for k in idx[1:]])
             idx = []
             counter += 1
-    return cell_type, numpy.array(cells), cell_ids, line
+
+    cell_sets = (
+        {values["ELSET"]: numpy.arange(counter, dtype="int32")}
+        if "ELSET" in values.keys()
+        else {}
+    )
+
+    return cell_type, numpy.array(cells), cell_ids, cell_sets, line
 
 
 def get_param_map(word, required_keys=None):

--- a/test/meshes/abaqus/element_elset.inp
+++ b/test/meshes/abaqus/element_elset.inp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:237a2d843cbe692b95cf9d09a1b23d7f079336b99a0c36484927c949e09955a6
+size 184

--- a/test/test_abaqus.py
+++ b/test/test_abaqus.py
@@ -49,7 +49,7 @@ def test_reference_file(filename, ref_sum, ref_num_cells, ref_num_cell_sets):
 
 def test_elset():
     points = numpy.array(
-        [[1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [2.0, 0.5, 0.0], [0.0, 0.5, 0.0],]
+        [[1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [2.0, 0.5, 0.0], [0.0, 0.5, 0.0]]
     )
     cells = [
         ("triangle", numpy.array([[0, 1, 2]])),

--- a/test/test_abaqus.py
+++ b/test/test_abaqus.py
@@ -30,7 +30,7 @@ def test(mesh):
 
 @pytest.mark.parametrize(
     "filename, ref_sum, ref_num_cells, ref_num_cell_sets",
-    [("UUea.inp", 4950.0, 50, 10), ("nle1xf3c.inp", 32.215275528, 12, 2)],
+    [("UUea.inp", 4950.0, 50, 10), ("nle1xf3c.inp", 32.215275528, 12, 3)],
 )
 def test_reference_file(filename, ref_sum, ref_num_cells, ref_num_cell_sets):
     this_dir = os.path.dirname(os.path.abspath(__file__))

--- a/test/test_abaqus.py
+++ b/test/test_abaqus.py
@@ -30,7 +30,11 @@ def test(mesh):
 
 @pytest.mark.parametrize(
     "filename, ref_sum, ref_num_cells, ref_num_cell_sets",
-    [("UUea.inp", 4950.0, 50, 10), ("nle1xf3c.inp", 32.215275528, 12, 3), ("element_elset.inp", 6.0, 2, 2)],
+    [
+        ("UUea.inp", 4950.0, 50, 10),
+        ("nle1xf3c.inp", 32.215275528, 12, 3),
+        ("element_elset.inp", 6.0, 2, 2),
+    ],
 )
 def test_reference_file(filename, ref_sum, ref_num_cells, ref_num_cell_sets):
     this_dir = os.path.dirname(os.path.abspath(__file__))

--- a/test/test_abaqus.py
+++ b/test/test_abaqus.py
@@ -30,7 +30,7 @@ def test(mesh):
 
 @pytest.mark.parametrize(
     "filename, ref_sum, ref_num_cells, ref_num_cell_sets",
-    [("UUea.inp", 4950.0, 50, 10), ("nle1xf3c.inp", 32.215275528, 12, 3)],
+    [("UUea.inp", 4950.0, 50, 10), ("nle1xf3c.inp", 32.215275528, 12, 3), ("element_elset.inp", 6.0, 2, 2)],
 )
 def test_reference_file(filename, ref_sum, ref_num_cells, ref_num_cell_sets):
     this_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
- Fixed: handle ``ELSET`` defined in ``ELEMENT``,
- Fixed: write error due to empty cell set for a given cell block,
- Fixed: wrong element number when writing cell sets with more than one cell block,
- Added: test file with ``ELSET`` defined in ``ELEMENT``,
- Added: test read and write of a mesh with cell sets.
