### PR TITLE
Add FLAC3D binary format

### DIFF
--- a/meshio/_cli/_binary.py
+++ b/meshio/_cli/_binary.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import pathlib
 
-from .. import ansys, gmsh, mdpa, ply, stl, vtk, vtu, xdmf
+from .. import ansys, flac3d, gmsh, mdpa, ply, stl, vtk, vtu, xdmf
 from .._helpers import _filetype_from_path, read, reader_map
 from ._helpers import _get_version_text
 
@@ -25,6 +25,8 @@ def binary(argv=None):
     # write it out
     if fmt == "ansys":
         ansys.write(args.infile, mesh, binary=True)
+    elif fmt == "flac3d":
+        flac3d.write(args.infile, mesh, binary=True)
     elif fmt == "gmsh":
         gmsh.write(args.infile, mesh, binary=True)
     elif fmt == "mdpa":

--- a/meshio/flac3d/_flac3d.py
+++ b/meshio/flac3d/_flac3d.py
@@ -265,7 +265,9 @@ def write(filename, mesh, float_fmt=".15e", binary=False):
 
     if binary:
         with open_file(filename, "wb") as f:
-            f.write(struct.pack("<2I", 1375135718, 3))  # Don't know what these values represent
+            f.write(
+                struct.pack("<2I", 1375135718, 3)
+            )  # Don't know what these values represent
             _write_points(f, mesh.points, binary)
             _write_cells(f, mesh.points, mesh.cells, binary)
             _write_zgroups(f, mesh.cell_data, mesh.field_data, binary)
@@ -308,7 +310,9 @@ def _write_cells(f, points, cells, binary):
                     zone + 1,
                 )
             )
-            f.write(struct.pack("<{}I".format((num_verts + 2) * num_cells), *tmp.ravel()))
+            f.write(
+                struct.pack("<{}I".format((num_verts + 2) * num_cells), *tmp.ravel())
+            )
             count += num_cells
     else:
         f.write("* ZONES\n")
@@ -340,7 +344,14 @@ def _write_zgroups(f, cell_data, field_data, binary):
             for k in sorted(zgroups.keys()):
                 num_chars, num_zones = len(labels[k]), len(zgroups[k])
                 fmt = "<H{}sH7sI{}I".format(num_chars, num_zones)
-                tmp = [num_chars, labels[k].encode("utf-8"), 7, slot, num_zones, *zgroups[k]]
+                tmp = [
+                    num_chars,
+                    labels[k].encode("utf-8"),
+                    7,
+                    slot,
+                    num_zones,
+                    *zgroups[k],
+                ]
                 f.write(struct.pack(fmt, *tmp))
         else:
             f.write("* ZONE GROUPS\n")

--- a/meshio/flac3d/_flac3d.py
+++ b/meshio/flac3d/_flac3d.py
@@ -365,7 +365,7 @@ def _write_zgroups(f, cell_data, field_data, binary):
 
 def _translate_zones(points, cells):
     """Reorder meshio cells to FLAC3D zones.
-    
+
     Four first points must form a right-handed coordinate system (outward normal vectors).
     Reorder corner points according to sign of scalar triple products.
     """

--- a/meshio/flac3d/_flac3d.py
+++ b/meshio/flac3d/_flac3d.py
@@ -269,7 +269,7 @@ def write(filename, mesh, float_fmt=".15e", binary=False):
             _write_points(f, mesh.points, binary)
             _write_cells(f, mesh.points, mesh.cells, binary)
             _write_zgroups(f, mesh.cell_data, mesh.field_data, binary)
-            f.write(struct.pack("2I", 0, 0))  # No face and face group
+            f.write(struct.pack("<2I", 0, 0))  # No face and face group
     else:
         with open_file(filename, "w") as f:
             f.write("* FLAC3D grid produced by meshio v{}\n".format(version))
@@ -282,7 +282,7 @@ def write(filename, mesh, float_fmt=".15e", binary=False):
 def _write_points(f, points, binary, float_fmt=None):
     """Write points coordinates."""
     if binary:
-        f.write(struct.pack("I", len(points)))
+        f.write(struct.pack("<I", len(points)))
         for i, point in enumerate(points):
             f.write(struct.pack("<I3d", i + 1, *point))
     else:
@@ -298,7 +298,7 @@ def _write_cells(f, points, cells, binary):
 
     count = 0
     if binary:
-        f.write(struct.pack("I", sum(len(c.data) for c in cells)))
+        f.write(struct.pack("<I", sum(len(c.data) for c in cells)))
         for _, zone in zones:
             num_cells, num_verts = zone.shape
             tmp = numpy.column_stack(
@@ -336,7 +336,7 @@ def _write_zgroups(f, cell_data, field_data, binary):
         if binary:
             slot = "Default".encode("utf-8")
 
-            f.write(struct.pack("I", len(zgroups)))
+            f.write(struct.pack("<I", len(zgroups)))
             for k in sorted(zgroups.keys()):
                 num_chars, num_zones = len(labels[k]), len(zgroups[k])
                 fmt = "<H{}sH7sI{}I".format(num_chars, num_zones)
@@ -349,7 +349,7 @@ def _write_zgroups(f, cell_data, field_data, binary):
                 _write_table(f, zgroups[k])
     else:
         if binary:
-            f.write(struct.pack("I", 0))
+            f.write(struct.pack("<I", 0))
 
 
 def _translate_zones(points, cells):

--- a/test/meshes/flac3d/flac3d_mesh_ex_bin.f3grid
+++ b/test/meshes/flac3d/flac3d_mesh_ex_bin.f3grid
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:023436d2cb186bbc9dfa8451b05eb334bec10086c0e2d4521d6eb155b09251a0
+size 9004

--- a/test/test_flac3d.py
+++ b/test/test_flac3d.py
@@ -1,3 +1,4 @@
+import copy
 import pathlib
 import sys
 
@@ -9,16 +10,20 @@ import meshio
 
 
 @pytest.mark.parametrize(
-    "mesh, binary",
+    "mesh, binary, data",
     [
-        (helpers.tet_mesh, False),
-        (helpers.hex_mesh, False),
-        (helpers.tet_mesh, True),
-        (helpers.hex_mesh, True),
-        # helpers.add_cell_data(helpers.tet_mesh, [("a", (), int)]),  # TODO
+        (helpers.tet_mesh, False, []),
+        (helpers.hex_mesh, False, []),
+        (helpers.tet_mesh, False, [1, 2]),
+        (helpers.tet_mesh, True, []),
+        (helpers.hex_mesh, True, []),
+        (helpers.tet_mesh, True, [1, 2]),
     ],
 )
-def test(mesh, binary):
+def test(mesh, binary, data):
+    if data:
+        mesh = copy.deepcopy(mesh)
+        mesh.cell_data["flac3d:zone"] = [numpy.array(data)]
     helpers.write_read(meshio.flac3d.write, meshio.flac3d.read, mesh, 1.0e-15)
 
 

--- a/test/test_flac3d.py
+++ b/test/test_flac3d.py
@@ -30,7 +30,9 @@ def test(mesh, binary, data):
 
 # the failure perhaps has to do with dictionary ordering
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="Fails with 3.5")
-@pytest.mark.parametrize("filename", ["flac3d_mesh_ex.f3grid", "flac3d_mesh_ex_bin.f3grid"])
+@pytest.mark.parametrize(
+    "filename", ["flac3d_mesh_ex.f3grid", "flac3d_mesh_ex_bin.f3grid"],
+)
 def test_reference_file(filename):
     this_dir = pathlib.Path(__file__).resolve().parent
     filename = this_dir / "meshes" / "flac3d" / filename

--- a/test/test_flac3d.py
+++ b/test/test_flac3d.py
@@ -24,7 +24,8 @@ def test(mesh, binary, data):
     if data:
         mesh = copy.deepcopy(mesh)
         mesh.cell_data["flac3d:zone"] = [numpy.array(data)]
-    helpers.write_read(meshio.flac3d.write, meshio.flac3d.read, mesh, 1.0e-15)
+    writer = lambda f, m: meshio.flac3d.write(f, m, binary=binary)
+    helpers.write_read(writer, meshio.flac3d.read, mesh, 1.0e-15)
 
 
 # the failure perhaps has to do with dictionary ordering

--- a/test/test_flac3d.py
+++ b/test/test_flac3d.py
@@ -9,22 +9,25 @@ import meshio
 
 
 @pytest.mark.parametrize(
-    "mesh",
+    "mesh, binary",
     [
-        helpers.tet_mesh,
-        helpers.hex_mesh,
+        (helpers.tet_mesh, False),
+        (helpers.hex_mesh, False),
+        (helpers.tet_mesh, True),
+        (helpers.hex_mesh, True),
         # helpers.add_cell_data(helpers.tet_mesh, [("a", (), int)]),  # TODO
     ],
 )
-def test(mesh):
+def test(mesh, binary):
     helpers.write_read(meshio.flac3d.write, meshio.flac3d.read, mesh, 1.0e-15)
 
 
 # the failure perhaps has to do with dictionary ordering
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="Fails with 3.5")
-def test_reference_file():
+@pytest.mark.parametrize("filename", ["flac3d_mesh_ex.f3grid", "flac3d_mesh_ex_bin.f3grid"])
+def test_reference_file(filename):
     this_dir = pathlib.Path(__file__).resolve().parent
-    filename = this_dir / "meshes" / "flac3d" / "flac3d_mesh_ex.f3grid"
+    filename = this_dir / "meshes" / "flac3d" / filename
 
     mesh = meshio.read(filename)
 

--- a/test/test_flac3d.py
+++ b/test/test_flac3d.py
@@ -24,8 +24,12 @@ def test(mesh, binary, data):
     if data:
         mesh = copy.deepcopy(mesh)
         mesh.cell_data["flac3d:zone"] = [numpy.array(data)]
-    writer = lambda f, m: meshio.flac3d.write(f, m, binary=binary)
-    helpers.write_read(writer, meshio.flac3d.read, mesh, 1.0e-15)
+    helpers.write_read(
+        lambda f, m: meshio.flac3d.write(f, m, binary=binary),
+        meshio.flac3d.read,
+        mesh,
+        1.0e-15,
+    )
 
 
 # the failure perhaps has to do with dictionary ordering


### PR DESCRIPTION
**Features**
- Added: FLAC3D binary reader and writer,
- Added: test binary reader and writer.

**Notes**
- Since there is no documentation, this format has been completely guessed from trials and errors (and knowledge of the ASCII format),
- Binary files created by FLAC3D can be read by `meshio` and vice-versa.
- Benchmark on a mesh with 2.3M tets:

| | ASCII | Binary |
|-:|:-:|:-:|
| Read | 10.8 s | 7.7 s |
| Write | 11.2 s | 2.3 s|