### PR TITLE
Medit (.mesh): Fix parsing Dimension on separate line 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,5 +8,6 @@
 *.ply filter=lfs diff=lfs merge=lfs -text
 *.vtk filter=lfs diff=lfs merge=lfs -text
 *.ugrid filter=lfs diff=lfs merge=lfs -text
+*.mesh filter=lfs diff=lfs merge=lfs -text
 *.meshb filter=lfs diff=lfs merge=lfs -text
 *.tec filter=lfs diff=lfs merge=lfs -text

--- a/meshio/medit/_medit.py
+++ b/meshio/medit/_medit.py
@@ -204,7 +204,12 @@ def read_ascii_buffer(f):
             version = items[1]
             dtype = {"1": c_float, "2": c_double}[version]
         elif items[0] == "Dimension":
-            dim = int(items[1])
+            if len(items) >= 2:
+                dim = int(items[1])
+            else:
+                dim = int(
+                    int(f.readline())
+                )  # e.g. Dimension\n3, where the number of dimensions is on the next line
         elif items[0] == "Vertices":
             if dim <= 0:
                 raise ReadError()

--- a/test/meshes/medit/cube86.mesh
+++ b/test/meshes/medit/cube86.mesh
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ecbf7b48edc448fcbe2d28aba387c5d77ec535c6ebbd2977325101afd7834e8
+size 3331

--- a/test/test_medit.py
+++ b/test/test_medit.py
@@ -50,6 +50,7 @@ def test_generic_io():
             {1: 432, 2: 216, 3: 216},
         ),
         ("hch_strct.4.meshb", 306, 12, 178, 96, 0, 144, {1: 15, 2: 15, 3: 160}),
+        ("cube86.mesh", 39, 72, 0, 0, 86, 0, {1: 14, 2: 14, 3: 14, 4: 8, 5: 14, 6: 8}),
     ],
 )
 def test_reference_file(
@@ -97,7 +98,7 @@ def test_reference_file(
 
     if ref_num_tet > 0:
         c = mesh.cells[medit_meshio_id["tetra"]]
-        assert mesh.cells[1].data.shape == (ref_num_tet, 4)
+        assert c.data.shape == (ref_num_tet, 4)
     else:
         assert medit_meshio_id["tetra"] is None
 


### PR DESCRIPTION
Fixes #802

The test example is from: [`cube86.mesh`](https://people.sc.fsu.edu/~jburkardt/data/medit/cube86.mesh)