### PR TITLE
Add FLAC3D format to meshio-ascii

### DIFF
--- a/meshio/_cli/_ascii.py
+++ b/meshio/_cli/_ascii.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import pathlib
 
-from .. import ansys, gmsh, mdpa, ply, stl, vtk, vtu, xdmf
+from .. import ansys, flac3d, gmsh, mdpa, ply, stl, vtk, vtu, xdmf
 from .._helpers import _filetype_from_path, read, reader_map
 from ._helpers import _get_version_text
 
@@ -25,6 +25,8 @@ def ascii(argv=None):
     # write it out
     if fmt == "ansys":
         ansys.write(args.infile, mesh, binary=False)
+    elif fmt == "flac3d":
+        flac3d.write(args.infile, mesh, binary=False)
     elif fmt == "gmsh":
         gmsh.write(args.infile, mesh, binary=False)
     elif fmt == "mdpa":

--- a/meshio/flac3d/_flac3d.py
+++ b/meshio/flac3d/_flac3d.py
@@ -263,22 +263,22 @@ def write(filename, mesh, float_fmt=".16e", binary=False):
     if not any(c.type in meshio_only.keys() for c in mesh.cells):
         raise WriteError("FLAC3D format only supports 3D cells")
 
-    if binary:
-        with open_file(filename, "wb") as f:
+    mode = "wb" if binary else "w"
+    with open_file(filename, mode) as f:
+        if binary:
             f.write(
                 struct.pack("<2I", 1375135718, 3)
             )  # Don't know what these values represent
-            _write_points(f, mesh.points, binary)
-            _write_cells(f, mesh.points, mesh.cells, binary)
-            _write_zgroups(f, mesh.cell_data, mesh.field_data, binary)
-            f.write(struct.pack("<2I", 0, 0))  # No face and face group
-    else:
-        with open_file(filename, "w") as f:
+        else:
             f.write("* FLAC3D grid produced by meshio v{}\n".format(version))
             f.write("* {}\n".format(time.ctime()))
-            _write_points(f, mesh.points, binary, float_fmt)
-            _write_cells(f, mesh.points, mesh.cells, binary)
-            _write_zgroups(f, mesh.cell_data, mesh.field_data, binary)
+
+        _write_points(f, mesh.points, binary, float_fmt)
+        _write_cells(f, mesh.points, mesh.cells, binary)
+        _write_zgroups(f, mesh.cell_data, mesh.field_data, binary)
+
+        if binary:
+            f.write(struct.pack("<2I", 0, 0))  # No face and face group
 
 
 def _write_points(f, points, binary, float_fmt=None):


### PR DESCRIPTION
- Changed: reorganize FLAC3D writer (less duplicate code),
- Added: FLAC3D format to `meshio-ascii` (forgotten in PR #799).