### PR TITLE
enable import of raw binary VTU for Python 3.5

### DIFF
--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -201,7 +201,7 @@ class VtuReader:
         try:
             tree = ET.parse(filename, parser)
             root = tree.getroot()
-        except ET.ParseError:
+        except (ET.ParseError, TypeError):
             root = _parse_raw_binary(filename)
 
         if root.tag != "VTKFile":


### PR DESCRIPTION
fixes a Python 3.5 issue in GH-813