### PR TITLE
Enable reading compressed raw VTU files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ meshio can read and write all of the following and smoothly converts between the
  [SVG](https://www.w3.org/TR/SVG/) (2D only, output only),
  [UGRID](http://www.simcenter.msstate.edu/software/downloads/doc/ug_io/3d_grid_file_type_ugrid.html),
  [VTK](https://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf),
- [VTU](https://www.vtk.org/Wiki/VTK_XML_Formats) (except compressed raw binary data),
+ [VTU](https://www.vtk.org/Wiki/VTK_XML_Formats),
  [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) ([TIN](https://en.wikipedia.org/wiki/Triangulated_irregular_network)),
  [XDMF](http://www.xdmf.org/index.php/XDMF_Model_and_Format).
 

--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -137,7 +137,7 @@ def get_grid(root):
 def _parse_raw_binary(filename):
     import xml.etree.ElementTree as ET
 
-    with open(filename, "rb") as f:
+    with open(str(filename), "rb") as f:
         raw = f.read()
 
     try:

--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -137,7 +137,7 @@ def get_grid(root):
 def _parse_raw_binary(filename):
     import xml.etree.ElementTree as ET
 
-    with open(str(filename), "rb") as f:
+    with open(filename, "rb") as f:
         raw = f.read()
 
     try:
@@ -238,10 +238,10 @@ class VtuReader:
 
         parser = ET.XMLParser()
         try:
-            tree = ET.parse(filename, parser)
+            tree = ET.parse(str(filename), parser)
             root = tree.getroot()
         except ET.ParseError:
-            root = _parse_raw_binary(filename)
+            root = _parse_raw_binary(str(filename))
 
         if root.tag != "VTKFile":
             raise ReadError()

--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -391,7 +391,9 @@ class VtuReader:
                 "<" if self.byte_order == "LittleEndian" else ">"
             )
         num_bytes_per_item = numpy.dtype(dtype).itemsize
-        total_num_bytes = int(numpy.frombuffer(byte_string[:num_bytes_per_item], dtype)[0])
+        total_num_bytes = int(
+            numpy.frombuffer(byte_string[:num_bytes_per_item], dtype)[0]
+        )
 
         # Check if block size was decoded separately
         # (so decoding stopped after block size due to padding)

--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -240,7 +240,7 @@ class VtuReader:
         try:
             tree = ET.parse(filename, parser)
             root = tree.getroot()
-        except (ET.ParseError, TypeError):
+        except ET.ParseError:
             root = _parse_raw_binary(filename)
 
         if root.tag != "VTKFile":

--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -201,7 +201,7 @@ class VtuReader:
         try:
             tree = ET.parse(filename, parser)
             root = tree.getroot()
-        except ET.ParseError:
+        except (ET.ParseError, TypeError):
             root = _parse_raw_binary(filename)
 
         if root.tag != "VTKFile":

--- a/test/meshes/vtu/01_raw_binary_int64.vtu
+++ b/test/meshes/vtu/01_raw_binary_int64.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb4b45be9b5174d8c7a442b1587f2cfc7566a68cf4d93a0aa93ed95e4436f241
+size 11058

--- a/test/meshes/vtu/02_raw_compressed.vtu
+++ b/test/meshes/vtu/02_raw_compressed.vtu
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b6b8e8fabfdf3644ac05e76bd2073efa3e50ef411b8c8d3fb2f7fa7118e9725
+size 2712

--- a/test/test_vtu.py
+++ b/test/test_vtu.py
@@ -39,9 +39,7 @@ def test(mesh, data_type):
     binary, compression = data_type
 
     def writer(*args, **kwargs):
-        return meshio.vtu.write(
-            *args, binary=binary, compression=compression, **kwargs,
-        )
+        return meshio.vtu.write(*args, binary=binary, compression=compression, **kwargs)
 
     # ASCII files are only meant for debugging, VTK stores only 11 digits
     # <https://gitlab.kitware.com/vtk/vtk/issues/17038#note_264052>
@@ -57,7 +55,11 @@ def test_generic_io():
 
 @pytest.mark.parametrize(
     "filename, ref_cells, ref_num_cells, ref_num_pnt",
-    [("00_raw_binary.vtu", "tetra", 162, 64)],
+    [
+        ("00_raw_binary.vtu", "tetra", 162, 64),
+        ("01_raw_binary_int64.vtu", "tetra", 162, 64),
+        ("02_raw_compressed.vtu", "tetra", 162, 64),
+    ],
 )
 def test_read_from_file(filename, ref_cells, ref_num_cells, ref_num_pnt):
     this_dir = pathlib.Path(__file__).resolve().parent


### PR DESCRIPTION
Morever, this PR fixes an issue of GH-813 with UInt64 encoding and unaligned array data to mixed types.

Should also fix #793 (though I'm not sure since I'm still not able to read the example mesh, see comment in #793)