### PR TITLE
Fix for vtu scalar DataArray with NumberOfComponents

### DIFF
--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -491,7 +491,7 @@ class VtuReader:
         else:
             raise ReadError("Unknown data format '{}'.".format(fmt))
 
-        if "NumberOfComponents" in c.attrib:
+        if "NumberOfComponents" in c.attrib and int(c.attrib["NumberOfComponents"]) > 1:
             data = data.reshape(-1, int(c.attrib["NumberOfComponents"]))
         return data
 

--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -100,7 +100,10 @@ def _organize_cells(point_offsets, cells, cell_data_raw):
     out_cells = []
     for offset, cls, cdr in zip(point_offsets, cells, cell_data_raw):
         cls, cell_data = _cells_from_data(
-            cls["connectivity"], cls["offsets"], cls["types"], cdr
+            cls["connectivity"].ravel(),
+            cls["offsets"].ravel(),
+            cls["types"].ravel(),
+            cdr,
         )
         for c in cls:
             out_cells.append(CellBlock(c.type, c.data + offset))
@@ -491,7 +494,7 @@ class VtuReader:
         else:
             raise ReadError("Unknown data format '{}'.".format(fmt))
 
-        if "NumberOfComponents" in c.attrib and int(c.attrib["NumberOfComponents"]) > 1:
+        if "NumberOfComponents" in c.attrib:
             data = data.reshape(-1, int(c.attrib["NumberOfComponents"]))
         return data
 


### PR DESCRIPTION
Hi,

I'm facing a small issue with some vtu files created by a third-party software. Contrary to Paraview, this program adds the "NumberOfComponents" tag to all DataArray; even for scalar data "NumberOfComponents=1" is added. Meshio fails to read these files since it creates 2 dimensional numpy arrays for scalar data, while 1 dimensional arrays are expected further on the code. This leads to errors like the following:
```console
  File "/home/miche/workspace/meshio/meshio/vtu/_vtu.py", line 48, in _cells_from_data
    meshio_type = vtk_to_meshio_type[types[start]]
TypeError: unhashable type: 'numpy.ndarray'
```
In vtu files exported by Paraview, the "NumberOfComponents" tag is only added in case of vector or tensor data. Nevertheless, Paraview can read these third-party files without issue and it seems this shouldn't cause a failure in meshio either. This pull request fixes this small issue.
 