### PR TITLE
Gmsh: Fix v2.2 reader producing bad cell data arrays

### DIFF
--- a/meshio/gmsh/_gmsh22.py
+++ b/meshio/gmsh/_gmsh22.py
@@ -74,8 +74,13 @@ def read_buffer(f, is_ascii, data_size):
     for tag_name, tag_dict in cell_tags.items():
         if tag_name not in cell_data:
             cell_data[tag_name] = []
-        for cell_type, _ in cells:
+        offset = {}
+        for cell_type, cell_array in cells:
+            start = offset.setdefault(cell_type, 0)
+            end = start + len(cell_array)
+            offset[cell_type] = end
             tags = tag_dict.get(cell_type, [])
+            tags = numpy.array(tags[start:end], dtype=c_int)
             cell_data[tag_name].append(tags)
 
     return Mesh(


### PR DESCRIPTION
This bug shows up if all cells of the same type are not listed consecutively in the file. This reader generates a new cell block each time there is a cell type change in the file. Therefore, the cell data array lengths should agree with the number of cells on each cell block.

This bugs do not normally trigger with files generated from the Gmsh app. However, other mesh generators like Pointwise, when exporting to v2.2 format, produce files where cells of a given type are not all packed together in the file. The file is still valid and follows the documented format, but then meshio's reader produces cell data arrays with values for all cells of a given type rather than for the cells in the corresponding cell block.