### PR TITLE
Fix node ordering of the vtkWedge element

### DIFF
--- a/meshio/_common.py
+++ b/meshio/_common.py
@@ -229,3 +229,21 @@ vtk_to_meshio_type = {
     # 67: VTK_HIGHER_ORDER_HEXAHEDRON,
 }
 meshio_to_vtk_type = {v: k for k, v in vtk_to_meshio_type.items()}
+
+
+def _vtk_to_meshio_order(vtk_type, numnodes=-1, dtype=int):
+    if vtk_type == 13:
+        return numpy.array([0, 2, 1, 3, 5, 4], dtype=dtype)
+    else:
+        if numnodes == -1:
+            num_nodes_per_cell[vtk_to_meshio_type[vtk_type]]
+        return numpy.arange(0, numnodes, dtype=dtype)
+
+
+def _meshio_to_vtk_order(meshio_type, numnodes=-1, dtype=int):
+    if meshio_type == "wedge":
+        return numpy.array([0, 2, 1, 3, 5, 4], dtype=dtype)
+    else:
+        if numnodes == -1:
+            num_nodes_per_cell[meshio_type]
+        return numpy.arange(0, numnodes, dtype=dtype)

--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -14,6 +14,8 @@ import numpy
 
 from ..__about__ import __version__
 from .._common import (
+    _meshio_to_vtk_order,
+    _vtk_to_meshio_order,
     meshio_to_vtk_type,
     num_nodes_per_cell,
     raw_from_cell_data,
@@ -70,7 +72,8 @@ def _cells_from_data(connectivity, offsets, types, cell_data_raw):
             for sz in numpy.unique(size):
                 items = numpy.where(size == sz)[0]
                 indices = numpy.add.outer(
-                    start_cn[items + 1], numpy.arange(-sz, 0, dtype=offsets.dtype)
+                    start_cn[items + 1],
+                    _vtk_to_meshio_order(types[start], sz, dtype=offsets.dtype) - sz,
                 )
                 cells.append(CellBlock(meshio_type + str(sz), connectivity[indices]))
                 # Store cell data for this set of cells
@@ -82,7 +85,8 @@ def _cells_from_data(connectivity, offsets, types, cell_data_raw):
             # Same number of nodes per cell
             n = num_nodes_per_cell[meshio_type]
             indices = numpy.add.outer(
-                offsets[start:end], numpy.arange(-n, 0, dtype=offsets.dtype)
+                offsets[start:end],
+                _vtk_to_meshio_order(types[start], n, dtype=offsets.dtype) - n,
             )
             cells.append(CellBlock(meshio_type, connectivity[indices]))
             for name, d in cell_data_raw.items():
@@ -658,7 +662,9 @@ def write(filename, mesh, binary=True, compression="zlib", header_type=None):
         cls = ET.SubElement(piece, "Cells")
 
         # create connectivity, offset, type arrays
-        connectivity = numpy.concatenate([v.data.reshape(-1) for v in mesh.cells])
+        connectivity = numpy.concatenate(
+            [v.data[:, _meshio_to_vtk_order(v.type)].reshape(-1) for v in mesh.cells]
+        )
 
         # offset (points to the first element of the next cell)
         offsets = [


### PR DESCRIPTION
Wedge6 elements are currently converted as-is between gmsh and vtk/vtu formats. However, the gmsh Prism element and the vtkWedge actually have a different node ordering; compare http://gmsh.info/doc/texinfo/gmsh.html#Node-ordering and https://lorensen.github.io/VTKExamples/site/VTKFileFormats/: the normal of the (0,1,2) triangle in the gmsh element points inwards, while this normal points outwards in the vtkWedge.
As a result, converting these elements from gmsh format to vtk or vtu format leads to elements with a negative volume in Paraview. This can be checked by running the MWE in attachment ([wedge6.txt](https://github.com/nschloe/meshio/files/4906939/wedge6.txt)) to create a wedge element in gmsh, followed by:
`gmsh wedge6.txt`
`meshio-convert wedge6.msh wedge6.vtk`
Inspecting the element's volume in Paraview (using the Cell Size filter) shows that the element has a negative volume.
While meshio mostly follows the vtk node ordering, I think it would be better to use the gmsh ordering in this case, since this one seems to be more conventional: the gmsh convention is used in most other formats (Ansys, Nastran, ...). In fact, the vtkWedge also uses a different ordering than the vtkHigherOrderWedge; see e.g.:
https://gitlab.kitware.com/vtk/vtk/-/merge_requests/6821
https://vtk.org/doc/nightly/html/classvtkHigherOrderWedge.html

This PR therefore proposes a fix which converts the vtkWedge ordering while reading/writing vtk and vtu files.