### PR TITLE
Fix node ordering of the vtkWedge element

### DIFF
--- a/meshio/_common.py
+++ b/meshio/_common.py
@@ -232,6 +232,12 @@ meshio_to_vtk_type = {v: k for k, v in vtk_to_meshio_type.items()}
 
 
 def _vtk_to_meshio_order(vtk_type, numnodes, dtype=int):
+    # meshio uses the same node ordering as VTK for most cell types. However, for the
+    # linear wedge, the ordering of the gmsh Prism [1] is adopted since this is found in
+    # most codes (Abaqus, Ansys, Nastran,...). In the vtkWedge [2], the normal of the
+    # (0,1,2) triangle points outwards, while in gmsh this normal points inwards.
+    # [1] http://gmsh.info/doc/texinfo/gmsh.html#Node-ordering
+    # [2] https://vtk.org/doc/nightly/html/classvtkWedge.html
     if vtk_type == 13:
         return numpy.array([0, 2, 1, 3, 5, 4], dtype=dtype)
     else:

--- a/meshio/_common.py
+++ b/meshio/_common.py
@@ -229,3 +229,17 @@ vtk_to_meshio_type = {
     # 67: VTK_HIGHER_ORDER_HEXAHEDRON,
 }
 meshio_to_vtk_type = {v: k for k, v in vtk_to_meshio_type.items()}
+
+
+def _vtk_to_meshio_order(vtk_type, numnodes, dtype=int):
+    if vtk_type == 13:
+        return numpy.array([0, 2, 1, 3, 5, 4], dtype=dtype)
+    else:
+        return numpy.arange(0, numnodes, dtype=dtype)
+
+
+def _meshio_to_vtk_order(meshio_type, numnodes, dtype=int):
+    if meshio_type == "wedge":
+        return numpy.array([0, 2, 1, 3, 5, 4], dtype=dtype)
+    else:
+        return numpy.arange(0, numnodes, dtype=dtype)


### PR DESCRIPTION
Wedge6 elements are currently converted as-is between gmsh and vtk/vtu formats. However, the gmsh Prism element and the vtkWedge have in fact a different node ordering; compare http://gmsh.info/doc/texinfo/gmsh.html#Node-ordering and https://lorensen.github.io/VTKExamples/site/VTKFileFormats/: the normal of the (0,1,2) triangle in the gmsh element points inwards, while this normal points outwards in the vtkWedge.
As a result, converting these elements from gmsh format to vtk or vtu format leads to elements with a negative volume in Paraview. This can be checked by running the MWE in attachment ([wedge6.txt](https://github.com/nschloe/meshio/files/4907066/wedge6.txt)) to create a wedge element in gmsh, followed by:
`gmsh wedge6.txt`
`meshio-convert wedge6.msh wedge6.vtk`
Inspecting the element's volume in Paraview (using the Cell Size filter) shows that the element has a negative volume.
While meshio mostly follows the vtk node ordering, I think it would be better to use the gmsh ordering in this case, since this one seems to be more conventional: the gmsh convention is used in most other formats (Ansys, Nastran, ...). In fact, the vtkWedge also uses a different ordering than the vtkHigherOrderWedge; see e.g.:
https://gitlab.kitware.com/vtk/vtk/-/merge_requests/6821
https://vtk.org/doc/nightly/html/classvtkHigherOrderWedge.html

This PR therefore proposes a fix which converts the vtkWedge ordering while reading/writing vtk and vtu files.

(Sorry for creating this PR twice)