### PR TITLE
Add hexahedron27 and pyramid13 in _gmsh_to_meshio_order

### DIFF
--- a/meshio/gmsh/common.py
+++ b/meshio/gmsh/common.py
@@ -87,6 +87,7 @@ _gmsh_to_meshio_type = {
     16: "quad8",
     17: "hexahedron20",
     18: "wedge15",
+    19: "pyramid13",
     21: "triangle10",
     23: "triangle15",
     25: "triangle21",
@@ -156,10 +157,15 @@ def _gmsh_to_meshio_order(cells):
             0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 13,
             9, 16, 18, 19, 17, 10, 12, 14, 15,
         ],  # https://vtk.org/doc/release/4.2/html/classvtkQuadraticHexahedron.html and https://gmsh.info/doc/texinfo/gmsh.html#Node-ordering
+        "hexahedron27": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 13,
+            9, 16, 18, 19, 17, 10, 12, 14, 15,
+            22, 23, 21, 24, 20, 25, 26,
+        ],
         "wedge15": [
             0, 1, 2, 3, 4, 5, 6, 9, 7, 12, 14, 13, 8, 10, 11
-        ],
-        # http://davis.lbl.gov/Manuals/VTK-4.5/classvtkQuadraticWedge.html and https://gmsh.info/doc/texinfo/gmsh.html#Node-ordering
+        ],  # http://davis.lbl.gov/Manuals/VTK-4.5/classvtkQuadraticWedge.html and https://gmsh.info/doc/texinfo/gmsh.html#Node-ordering
+        "pyramid13": [0, 1, 2, 3, 4, 5, 8, 10, 6, 7, 9, 11, 12],
         # fmt: on
     }
     return _reorder_cells(cells, meshio_ordering)
@@ -174,9 +180,15 @@ def _meshio_to_gmsh_order(cells):
             0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 16,
             9, 17, 10, 18, 19, 12, 15, 13, 14,
         ],
+        "hexahedron27": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 16,
+            9, 17, 10, 18, 19, 12, 15, 13, 14,
+            24, 22, 20, 21, 23, 25, 26,
+        ],
         "wedge15": [
             0, 1, 2, 3, 4, 5, 6, 8, 12, 7, 13, 14, 9, 11, 10,
         ],
+        "pyramid13": [0, 1, 2, 3, 4, 5, 8, 9, 6, 10, 7, 11, 12],
         # fmt: on
     }
     return _reorder_cells(cells, gmsh_ordering)


### PR DESCRIPTION
Hi, I went ahead and added the node ordering for the hexahedron27 and pyramid13 elements in the gmsh reader. I tested the conversion between gmsh and paraview for a mesh containing hexahedron27 elements and it works fine now. I didn't test the pyramid13 element but it should be fine. I think those were the last missing second-order elements.