### PR TITLE
Msh4 to msh2

### DIFF
--- a/meshio/gmsh/_gmsh22.py
+++ b/meshio/gmsh/_gmsh22.py
@@ -352,10 +352,10 @@ def _write_elements(fh, cells, tag_data, binary):
     for k, (cell_type, node_idcs) in enumerate(cells):
         tags = []
         for name in ["gmsh:physical", "gmsh:geometrical", "cell_tags"]:
-            try:
+            if name in tag_data:
                 tags.append(tag_data[name][k])
-            except KeyError:
-                pass
+            elif name in ["gmsh:physical", "gmsh:geometrical"]:
+                tags.append(numpy.zeros(len(node_idcs), dtype=int))
         fcd = numpy.concatenate([tags]).astype(c_int).T
 
         if len(fcd) == 0:

--- a/meshio/gmsh/_gmsh22.py
+++ b/meshio/gmsh/_gmsh22.py
@@ -277,6 +277,25 @@ def write(filename, mesh, float_fmt=".16e", binary=True):
             [mesh.points[:, 0], mesh.points[:, 1], numpy.zeros(mesh.points.shape[0])]
         )
 
+    # Split the cell data: gmsh:physical and gmsh:geometrical are tags, the rest is
+    # actual cell data.
+    tag_data = {}
+    other_data = {}
+    for key, d in mesh.cell_data.items():
+        if key in ["gmsh:physical", "gmsh:geometrical", "cell_tags"]:
+            tag_data[key] = d
+        else:
+            other_data[key] = d
+
+    # Always include the physical and geometrical tags. See also the quoted excerpt from
+    # the gmsh documentation in the _read_cells_ascii function above.
+    for tag in ["gmsh:physical", "gmsh:geometrical"]:
+        if tag not in tag_data:
+            logging.warning(
+                "Appending zeroes to replace the missing {} tag data.".format(tag[5:])
+            )
+            tag_data[tag] = [numpy.zeros(len(x.data), dtype=c_int) for x in mesh.cells]
+
     if binary:
         for k, (key, value) in enumerate(mesh.cells):
             if value.dtype != c_int:
@@ -301,16 +320,6 @@ def write(filename, mesh, float_fmt=".16e", binary=True):
 
         if mesh.field_data:
             _write_physical_names(fh, mesh.field_data)
-
-        # Split the cell data: gmsh:physical and gmsh:geometrical are tags, the rest is
-        # actual cell data.
-        tag_data = {}
-        other_data = {}
-        for key, d in mesh.cell_data.items():
-            if key in ["gmsh:physical", "gmsh:geometrical", "cell_tags"]:
-                tag_data[key] = d
-            else:
-                other_data[key] = d
 
         _write_nodes(fh, mesh.points, float_fmt, binary)
         _write_elements(fh, cells, tag_data, binary)
@@ -354,8 +363,6 @@ def _write_elements(fh, cells, tag_data, binary):
         for name in ["gmsh:physical", "gmsh:geometrical", "cell_tags"]:
             if name in tag_data:
                 tags.append(tag_data[name][k])
-            elif name in ["gmsh:physical", "gmsh:geometrical"]:
-                tags.append(numpy.zeros(len(node_idcs), dtype=int))
         fcd = numpy.concatenate([tags]).astype(c_int).T
 
         if len(fcd) == 0:

--- a/meshio/gmsh/_gmsh22.py
+++ b/meshio/gmsh/_gmsh22.py
@@ -292,7 +292,7 @@ def write(filename, mesh, float_fmt=".16e", binary=True):
     for tag in ["gmsh:physical", "gmsh:geometrical"]:
         if tag not in tag_data:
             logging.warning(
-                "Appending zeroes to replace the missing {} tag data.".format(tag[5:])
+                "Appending zeros to replace the missing {} tag data.".format(tag[5:])
             )
             tag_data[tag] = [numpy.zeros(len(x.data), dtype=c_int) for x in mesh.cells]
 

--- a/meshio/gmsh/_gmsh40.py
+++ b/meshio/gmsh/_gmsh40.py
@@ -187,9 +187,9 @@ def _read_elements(f, point_tags, physical_tags, is_ascii, data_size):
             (num_ele, -1)
         )
         if physical_tags is None:
-            data.append((None, tpe, d))
+            data.append((None, tag_entity, tpe, d))
         else:
-            data.append((physical_tags[dim_entity][tag_entity], tpe, d))
+            data.append((physical_tags[dim_entity][tag_entity], tag_entity, tpe, d))
 
     if not is_ascii:
         line = f.readline().decode("utf-8")
@@ -207,18 +207,24 @@ def _read_elements(f, point_tags, physical_tags, is_ascii, data_size):
     itags[point_tags] = numpy.arange(len(point_tags))
 
     # Note that the first column in the data array is the element tag; discard it.
-    data = [(physical_tag, tpe, itags[d[:, 1:]]) for physical_tag, tpe, d in data]
+    data = [
+        (physical_tag, geom_tag, tpe, itags[d[:, 1:]])
+        for physical_tag, geom_tag, tpe, d in data
+    ]
 
     cells = []
     cell_data = {}
-    for physical_tag, key, values in data:
+    for physical_tag, geom_tag, key, values in data:
         cells.append((key, values))
         if physical_tag:
             if "gmsh:physical" not in cell_data:
                 cell_data["gmsh:physical"] = []
             cell_data["gmsh:physical"].append(
-                physical_tag[0] * numpy.ones(len(values), int)
+                numpy.full(len(values), physical_tag[0], int)
             )
+        if "gmsh:geometrical" not in cell_data:
+            cell_data["gmsh:geometrical"] = []
+        cell_data["gmsh:geometrical"].append(numpy.full(len(values), geom_tag, int))
     cells[:] = _gmsh_to_meshio_order(cells)
 
     return cells, cell_data

--- a/meshio/gmsh/main.py
+++ b/meshio/gmsh/main.py
@@ -7,7 +7,7 @@ from . import _gmsh22, _gmsh40, _gmsh41
 
 # Some mesh files out there have the version specified as version "2" when it really is
 # "2.2". Same with "4" vs "4.1".
-_readers = {"2": _gmsh22, "2.2": _gmsh22, "4.0": _gmsh40, "4": _gmsh41, "4.1": _gmsh41}
+_readers = {"2": _gmsh22, "2.2": _gmsh22, "4.0": _gmsh40, "4": _gmsh40, "4.1": _gmsh41}
 _writers = {"2.2": _gmsh22, "4.0": _gmsh40, "4.1": _gmsh41}
 
 

--- a/meshio/gmsh/main.py
+++ b/meshio/gmsh/main.py
@@ -7,7 +7,7 @@ from . import _gmsh22, _gmsh40, _gmsh41
 
 # Some mesh files out there have the version specified as version "2" when it really is
 # "2.2". Same with "4" vs "4.1".
-_readers = {"2": _gmsh22, "2.2": _gmsh22, "4.0": _gmsh40, "4": _gmsh40, "4.1": _gmsh41}
+_readers = {"2": _gmsh22, "2.2": _gmsh22, "4.0": _gmsh40, "4": _gmsh41, "4.1": _gmsh41}
 _writers = {"2.2": _gmsh22, "4.0": _gmsh40, "4.1": _gmsh41}
 
 


### PR DESCRIPTION
Hi, I tried to use meshio to convert a gmsh41 file to a gmsh22 file and noticed that rereading this converted file in gmsh does not give a mesh with the same tags. This PR tries to fix this issue by mimicking the conversion behavior of gmsh itself. The following things are  modified:
1. When converting from gmsh4 to gmsh22 with meshio, the geometrical tag is missing in the resulting file. Change: the readers for gmsh40 and gmsh41 now also store the geometrical tag as cell data with the "gmsh:geometrical" key similar to the gmsh22 reader (edc7764).
2. If the `Entities` block is missing (which is allowed in the 4.1 format), the mesh file converted by gmsh will only contain the geometrical tag and the physical tags are set to zero to maintain the correct order (see number-of-tags entry [here](http://gmsh.info/doc/texinfo/gmsh.html#MSH-file-format-version-2-_0028Legacy_0029)). However, when using meshio to write a gmsh22 file of a mesh with "gmsh:geometrical" but without "gmsh:physical" tags, the geometrical tags are written directly after the element number. As a result, the geometrical tags are considered as physicals tags in gmsh. 2fbb8df fixes this by also writing a zero when either the physical or geometrical tag is missing.  
3. When `MeshFormat` is 4 (without decimals), the format corresponds to 4.0 instead of 4.1 (501eebd).