### PR TITLE
skip COLOR_SCALARS gracefully in vtk files

### DIFF
--- a/meshio/vtk/_vtk.py
+++ b/meshio/vtk/_vtk.py
@@ -113,6 +113,7 @@ vtk_sections = [
     "POINT_DATA",
     "CELL_DATA",
     "LOOKUP_TABLE",
+    "COLOR_SCALARS",
 ]
 
 
@@ -232,6 +233,15 @@ def _read_section(f, info):
         info.num_items = int(info.split[2])
         data = numpy.fromfile(f, count=info.num_items * 4, sep=" ", dtype=float)
         rgba = data.reshape((info.num_items, 4))  # noqa F841
+
+    elif info.section == "COLOR_SCALARS":
+        nValues = int(info.split[2])
+        # re-use num_items from active POINT/CELL_DATA
+        num_items = info.num_items
+        dtype = numpy.ubyte
+        if info.is_ascii:
+            dtype = float
+        data = numpy.fromfile(f, count=num_items * nValues, dtype=dtype)
 
 
 def _read_subsection(f, info):

--- a/test/meshes/vtk/06_color_scalars.vtk
+++ b/test/meshes/vtk/06_color_scalars.vtk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ce07ff71f44553e8d87f8a59c8a2702d9f9f4e51ce24b7ddb3775e050ea5320
+size 328

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -93,5 +93,17 @@ def test_pathlike():
     meshio.read(this_dir / "meshes" / "vtk" / "rbc_001.vtk")
 
 
+@pytest.mark.parametrize(
+    "filename, ref_num_points, ref_num_cells", [("06_color_scalars.vtk", 5, 2)]
+)
+def test_color_scalars(filename, ref_num_points, ref_num_cells):
+    this_dir = pathlib.Path(__file__).resolve().parent
+    filename = this_dir / "meshes" / "vtk" / filename
+
+    mesh = meshio.read(filename)
+    assert len(mesh.points) == ref_num_points
+    assert len(mesh.cells) == ref_num_cells
+
+
 if __name__ == "__main__":
     test(helpers.tri_mesh, binary=True)


### PR DESCRIPTION
This resolves #854 but the file attached to that issue cannot be read completly yet since it depends at least on #855 too.