### PR TITLE
Vtk5.1

### DIFF
--- a/meshio/vtk/_vtk.py
+++ b/meshio/vtk/_vtk.py
@@ -76,6 +76,7 @@ vtk_to_numpy_dtype_name = {
     "double": "float64",
     "vtktypeint32": "int32",  # vtk DataFile Version 5.1
     "vtktypeint64": "int64",  # vtk DataFile Version 5.1
+    "vtkidtype": "int32",  # may be either 32-bit or 64-bit (VTK_USE_64BIT_IDS)
 }
 
 numpy_to_vtk_dtype = {

--- a/meshio/vtk/_vtk.py
+++ b/meshio/vtk/_vtk.py
@@ -223,7 +223,11 @@ def _read_section(f, info):
             line = f.readline().decode("utf-8")
         except UnicodeDecodeError:
             line = ""
-        if "OFFSETS" in line:  # vtk DataFile Version 5.1
+        if "OFFSETS" in line:
+            # vtk DataFile Version 5.1 - appearing in Paraview 5.8.1 outputs
+            # No specification found for this file format.
+            # See the question on ParaView Discourse Forum:
+            # <https://discourse.paraview.org/t/specification-of-vtk-datafile-version-5-1/5127>.
             info.num_offsets = int(info.split[1])
             info.num_items = int(info.split[2])
             dtype = numpy.dtype(vtk_to_numpy_dtype_name[line.split()[1]])

--- a/meshio/vtk/_vtk.py
+++ b/meshio/vtk/_vtk.py
@@ -74,9 +74,13 @@ vtk_to_numpy_dtype_name = {
     "long": "int64",
     "float": "float32",
     "double": "float64",
+    "vtktypeint32": "int32",  # vtk DataFile Version 5.1
+    "vtktypeint64": "int64",  # vtk DataFile Version 5.1
 }
 
-numpy_to_vtk_dtype = {v: k for k, v in vtk_to_numpy_dtype_name.items()}
+numpy_to_vtk_dtype = {
+    v: k for k, v in vtk_to_numpy_dtype_name.items() if "vtk" not in k
+}
 
 # supported vtk dataset types
 vtk_dataset_types = [
@@ -213,8 +217,25 @@ def _read_section(f, info):
 
     elif info.section == "CELLS":
         info.active = "CELLS"
-        info.num_items = int(info.split[2])
-        info.c = _read_cells(f, info.is_ascii, info.num_items)
+        last_pos = f.tell()
+        try:
+            line = f.readline().decode("utf-8")
+        except UnicodeDecodeError:
+            line = ""
+        if "OFFSETS" in line:  # vtk DataFile Version 5.1
+            info.num_offsets = int(info.split[1])
+            info.num_items = int(info.split[2])
+            dtype = numpy.dtype(vtk_to_numpy_dtype_name[line.split()[1]])
+            offsets = _read_cells(f, info.is_ascii, info.num_offsets, dtype)
+            line = f.readline().decode("utf-8")
+            assert "CONNECTIVITY" in line
+            dtype = numpy.dtype(vtk_to_numpy_dtype_name[line.split()[1]])
+            connectivity = _read_cells(f, info.is_ascii, info.num_items, dtype)
+            info.c = (offsets, connectivity)
+        else:
+            f.seek(last_pos)
+            info.num_items = int(info.split[2])
+            info.c = _read_cells(f, info.is_ascii, info.num_items)
 
     elif info.section == "CELL_TYPES":
         info.active = "CELL_TYPES"
@@ -401,11 +422,12 @@ def _read_points(f, data_type, is_ascii, num_points):
     return points.reshape((num_points, 3))
 
 
-def _read_cells(f, is_ascii, num_items):
+def _read_cells(f, is_ascii, num_items, dtype=numpy.dtype("int32")):
     if is_ascii:
-        c = numpy.fromfile(f, count=num_items, sep=" ", dtype=int)
+        c = numpy.fromfile(f, count=num_items, sep=" ", dtype=dtype)
     else:
-        c = numpy.fromfile(f, count=num_items, dtype=">i4")
+        dtype = dtype.newbyteorder(">")
+        c = numpy.fromfile(f, count=num_items, dtype=dtype)
         line = f.readline().decode("utf-8")
         if line != "\n":
             raise ReadError()
@@ -528,6 +550,7 @@ def translate_cells(data, types, cell_data_raw):
     # Translate it into the cells array.
     # `data` is a one-dimensional vector with
     # (num_points0, p0, p1, ... ,pk, numpoints1, p10, p11, ..., p1k, ...
+    # or a tuple with (offsets, connectivity)
     has_polygon = numpy.any(types == meshio_to_vtk_type["polygon"])
 
     cells = []
@@ -574,20 +597,28 @@ def translate_cells(data, types, cell_data_raw):
         numnodes = vtk_type_to_numnodes[types]
         if not numpy.all(numnodes > 0):
             raise ReadError("File contains cells that meshio cannot handle.")
-        offsets = numpy.cumsum(numnodes + 1) - (numnodes + 1)
+        if isinstance(data, tuple):
+            offsets, conn = data
+            if not numpy.all(numnodes == numpy.diff(offsets)):
+                raise ReadError()
+            idx0 = 0
+        else:
+            offsets = numpy.cumsum(numnodes + 1) - (numnodes + 1)
 
-        if not numpy.all(numnodes == data[offsets]):
-            raise ReadError()
+            if not numpy.all(numnodes == data[offsets]):
+                raise ReadError()
+            idx0 = 1
+            conn = data
 
         b = numpy.concatenate(
             [[0], numpy.where(types[:-1] != types[1:])[0] + 1, [len(types)]]
         )
         for start, end in zip(b[:-1], b[1:]):
             meshio_type = vtk_to_meshio_type[types[start]]
-            n = data[offsets[start]]
-            cell_idx = 1 + _vtk_to_meshio_order(types[start], n, dtype=offsets.dtype)
+            n = numnodes[start]
+            cell_idx = idx0 + _vtk_to_meshio_order(types[start], n, dtype=offsets.dtype)
             indices = numpy.add.outer(offsets[start:end], cell_idx)
-            cells.append(CellBlock(meshio_type, data[indices]))
+            cells.append(CellBlock(meshio_type, conn[indices]))
             for name, d in cell_data_raw.items():
                 if name not in cell_data:
                     cell_data[name] = []

--- a/test/meshes/vtk/06_unstructured.vtk
+++ b/test/meshes/vtk/06_unstructured.vtk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bba5171c092aa0ed9714ab5fc9f3715b430500554e58e2b8dac3dd9443988414
+size 1201

--- a/test/test_vtk.py
+++ b/test/test_vtk.py
@@ -75,6 +75,7 @@ def test_reference_file(filename, ref_sum, ref_num_cells, binary):
         ("03_rectilinear.vtk", "hexahedron", 72, 147),
         ("04_rectilinear.vtk", "quad", 27, 40),
         ("05_rectilinear.vtk", "quad", 27, 40),
+        ("06_unstructured.vtk", "hexahedron", 12, 42),
     ],
 )
 def test_structured(filename, ref_cells, ref_num_cells, ref_num_pnt):


### PR DESCRIPTION
In `vtk DataFile Version 5.1` the cells are stored in OFFSETS/CONNECTIVITY data blocks.

My _Paraview_ v5.8 produces VTK files with `vtktypeint64` types after  OFFSETS/CONNECTIVITY keywords, so I added `vtktypeint32` and `vtktypeint64` to `vtk_to_numpy_dtype_name` dictionary.

When extracting points or cells in _Paraview_, the original ids are stored in fields `vtkOriginalPointIds`/`vtkOriginalCellIds` and their type is `vtkIdType`. This is usually `int` (`int32`) type, but it can also be `long` (`int64`). See file [1], lines 308-336. I don't know an easy way to determine it in the code.

This PR should fix #877.

[1]  https://vtk.org/doc/nightly/html/vtkType_8h_source.html