### PR TITLE
Add support for rational Bézier cells in vtk

### DIFF
--- a/meshio/_common.py
+++ b/meshio/_common.py
@@ -229,7 +229,6 @@ vtk_to_meshio_type = {
     # 65: VTK_HIGHER_ORDER_WEDGE,
     # 66: VTK_HIGHER_ORDER_PYRAMID,
     # 67: VTK_HIGHER_ORDER_HEXAHEDRON,
-
     # Arbitrary order Lagrange elements
     68: "VTK_LAGRANGE_CURVE",
     69: "VTK_LAGRANGE_TRIANGLE",
@@ -238,7 +237,6 @@ vtk_to_meshio_type = {
     72: "VTK_LAGRANGE_HEXAHEDRON",
     73: "VTK_LAGRANGE_WEDGE",
     74: "VTK_LAGRANGE_PYRAMID",
-
     # Arbitrary order Bezier elements
     75: "VTK_BEZIER_CURVE",
     76: "VTK_BEZIER_TRIANGLE",


### PR DESCRIPTION
Enable usage of rational Bézier cells in vtk files, see https://blog.kitware.com/implementation-of-rational-bezier-cells-into-vtk/ for the changes in vtk file format. This enables the usage of NURBS and B-Spline meshes when they are decomposed into Bézier patches.