### PR TITLE
Tetgen: read and write point/cell data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,5 @@
 *.meshb filter=lfs diff=lfs merge=lfs -text
 *.tec filter=lfs diff=lfs merge=lfs -text
 *.su2 filter=lfs diff=lfs merge=lfs -text
+*.ele filter=lfs diff=lfs merge=lfs -text
+*.node filter=lfs diff=lfs merge=lfs -text

--- a/test/meshes/tetgen/mesh.ele
+++ b/test/meshes/tetgen/mesh.ele
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a03caba0ddba428ddaf06f408132f44bf925173a6209be06a3cd2d98298c56e0
+size 5376

--- a/test/meshes/tetgen/mesh.node
+++ b/test/meshes/tetgen/mesh.node
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6002594138fc8dfc2e427e1c8f95c9dac1bc9434d1a9d00264f606513e8739b
+size 8724

--- a/test/test_tetgen.py
+++ b/test/test_tetgen.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import helpers
 import pytest
 
@@ -11,3 +13,15 @@ def test(mesh):
     helpers.write_read(
         meshio.tetgen.write, meshio.tetgen.read, mesh, 1.0e-15, extension=".node"
     )
+
+
+@pytest.mark.parametrize(
+    "filename, point_ref_sum, cell_ref_sum", [("mesh.ele", 12, 373)]
+)
+def test_point_cell_refs(filename, point_ref_sum, cell_ref_sum):
+    this_dir = pathlib.Path(__file__).resolve().parent
+    filename = this_dir / "meshes" / "tetgen" / filename
+
+    mesh = meshio.read(filename)
+    assert mesh.point_data["tetgen:ref"].sum() == point_ref_sum
+    assert mesh.cell_data["tetgen:ref"][0].sum() == cell_ref_sum


### PR DESCRIPTION
Reading:
* Nodes can have attributes and  boundary markers (see [2]), these are loaded into `point_data` dictionary using `tetgen:attr1`, `tetgen:attr2`, ... keys for the attributes and `tetgen:ref`, `tetgen:ref2`, ... keys for the markers. The first boundary marker (if exists) is assumed to be a _point group id_ and is labeled as `tetgen:ref`.
* Cells can only have attributes. A common use is to identify a subregion or material of cells (cell groups), see [1].  Cell attributes
are loaded as `tetgen:ref`, `tetgen:ref2`, ... cell data fields.

Writing:
* If there is a `:ref` field in `point_data`, it is used as the boundary marker, if not, the "first" field in point data is employed. The other `point_data` fields are stored as node attributes.
* If there is a `:ref` field in `cell_data`, it is used as the first region marker. 
* The names of point/cell data fields are stored in comment lines.

[1] http://wias-berlin.de/software/tetgen/fformats.ele.html
[2] http://wias-berlin.de/software/tetgen/fformats.node.html