### PR TITLE
stop at EOF and warn if $EndElements omitted

### DIFF
--- a/meshio/gmsh/_gmsh22.py
+++ b/meshio/gmsh/_gmsh22.py
@@ -137,7 +137,7 @@ def _read_cells(f, cells, point_tags, is_ascii):
         cells[ic] = (ct, remap[cd])
 
     for line in f:
-        if line.decode("utf-8") == "$EndElements":
+        if line.decode("utf-8") == "$EndElements\n":
             break
     else:
         logging.warning("$Elements not closed by $EndElements.")

--- a/meshio/gmsh/_gmsh22.py
+++ b/meshio/gmsh/_gmsh22.py
@@ -136,10 +136,11 @@ def _read_cells(f, cells, point_tags, is_ascii):
     for ic, (ct, cd) in enumerate(cells):
         cells[ic] = (ct, remap[cd])
 
-    # Fast forward to $EndElements
-    line = f.readline().decode("utf-8")
-    while line.strip() != "$EndElements":
-        line = f.readline().decode("utf-8")
+    for line in f:
+        if line.decode("utf-8") == "$EndElements":
+            break
+    else:
+        logging.warning("$Elements not closed by $EndElements.")
 
     # restrict to the standard two data items (physical, geometrical)
     output_cell_tags = {}


### PR DESCRIPTION
Fixes #913. 

Should a missing `$EndElements` raise a warning or an exception?

This just reads until it finds `$EndElements` or reaches the end of the file.  It doesn't attempt to handle files which begin a new block (e.g. `$NodeData`) without having closed the `$Elements` block; it will just read right through all that and ignore it.