### PR TITLE
Fix of the vtu polyhedron filter

### DIFF
--- a/meshio/_mesh.py
+++ b/meshio/_mesh.py
@@ -15,6 +15,7 @@ class Mesh:
         field_data=None,
         point_sets=None,
         cell_sets=None,
+        polyhedron_faces=None,
         gmsh_periodic=None,
         info=None,
     ):
@@ -38,6 +39,7 @@ class Mesh:
         self.field_data = {} if field_data is None else field_data
         self.point_sets = {} if point_sets is None else point_sets
         self.cell_sets = {} if cell_sets is None else cell_sets
+        self.polyhedron_faces = {} if polyhedron_faces is None else polyhedron_faces
         self.gmsh_periodic = gmsh_periodic
         self.info = info
 

--- a/meshio/_mesh.py
+++ b/meshio/_mesh.py
@@ -15,7 +15,6 @@ class Mesh:
         field_data=None,
         point_sets=None,
         cell_sets=None,
-        polyhedron_faces=None,
         gmsh_periodic=None,
         info=None,
     ):
@@ -39,7 +38,6 @@ class Mesh:
         self.field_data = {} if field_data is None else field_data
         self.point_sets = {} if point_sets is None else point_sets
         self.cell_sets = {} if cell_sets is None else cell_sets
-        self.polyhedron_faces = {} if polyhedron_faces is None else polyhedron_faces
         self.gmsh_periodic = gmsh_periodic
         self.info = info
 

--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -152,17 +152,12 @@ def _cells_from_data(connectivity, offsets, types, cell_data_raw):
                     start_cn[items + 1],
                     _vtk_to_meshio_order(types[start], sz, dtype=offsets.dtype) - sz,
                 )
-                if meshio_type == "polyhedron":
-                    # Polyhedra CellBlocks have special data
-                    cells.append(
-                        CellBlock(
-                            meshio_type + str(sz), polyhedron_faces[f"polyhedron{sz}"]
-                        )
-                    )
-                else:
-                    cells.append(
-                        CellBlock(meshio_type + str(sz), connectivity[indices])
-                    )
+                data = (
+                    polyhedron_faces[f"polyhedron{sz}"]
+                    if meshio_type == "polyhedron"
+                    else connectivity[indices]
+                )
+                cells.append(CellBlock(meshio_type + str(sz), data))
 
                 # Store cell data for this set of cells
                 for name, d in cell_data_raw.items():
@@ -640,6 +635,7 @@ def write(filename, mesh, binary=True, compression="zlib", header_type=None):
     for c in mesh.cells:
         if c.type[:10] == "polyhedron":
             is_polyhedron_grid = True
+            break
 
     if not binary:
         logging.warning("VTU ASCII files are only meant for debugging.")

--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -65,11 +65,6 @@ def _cells_from_data(connectivity, offsets, types, cell_data_raw):
                 #   ...
                 # num_faces_cell_1,
                 #   ...
-                #
-                # The faceoffsets describes the end of the face description for each
-                # cell, but this is 1-offset, so it is effectively the start of the
-                # next cell.
-                #
                 # See https://vtk.org/Wiki/VTK/Polyhedron_Support for more.
 
                 # There is a tacit assumption here that the cell-data keys 'faces'
@@ -85,6 +80,8 @@ def _cells_from_data(connectivity, offsets, types, cell_data_raw):
                     # in _organize_cells()
                     faces = cell_data_raw.pop("faces")
                     faceoffsets = cell_data_raw.pop("faceoffsets")
+                    # The faceoffsets describes the end of the face description for each
+                    # cell.
                     # Switch faceoffsets to give start points, not end points
                     faceoffsets = numpy.append([0], faceoffsets[:-1])
                     # Take note that we have found the faces

--- a/meshio/vtu/_vtu.py
+++ b/meshio/vtu/_vtu.py
@@ -43,10 +43,6 @@ def _cells_from_data(connectivity, offsets, types, cell_data_raw):
         [[0], numpy.where(types[:-1] != types[1:])[0] + 1, [len(types)]]
     )
 
-    # Check if polyhedron cells are discovered. If so, we need to pad the non-polyhedral
-    # cell data below.
-    has_polyhedron = False
-
     cells = []
     cell_data = {}
     polyhedron_faces = {}
@@ -59,8 +55,6 @@ def _cells_from_data(connectivity, offsets, types, cell_data_raw):
             # Polygons and polyhedra have unknown and varying number of nodes per cell.
 
             if meshio_type == "polyhedron":
-                has_polyhedron = True
-
                 # The data format for face-cells is:
                 # num_faces_cell_0,
                 #   num_nodes_face_0, node_ind_0, node_ind_1, ..

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -273,12 +273,12 @@ polyhedron_mesh = meshio.Mesh(
                     numpy.array([3, 0, 7]),
                 ],
                 [
-                    numpy.array([0, 1, 6]),  # pyramid base split in two triangles
-                    numpy.array([0, 6, 7]),
-                    numpy.array([0, 1, 5]),
-                    numpy.array([0, 5, 7]),
-                    numpy.array([5, 6, 7]),
-                    numpy.array([1, 5, 6]),
+                    numpy.array([0, 1, 5]),  # pyramid base split in two triangles
+                    numpy.array([0, 4, 5]),
+                    numpy.array([0, 1, 7]),
+                    numpy.array([1, 5, 7]),
+                    numpy.array([5, 4, 7]),
+                    numpy.array([0, 4, 7]),
                 ],
             ],
         ),

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -233,7 +233,7 @@ polygon_mesh = meshio.Mesh(
 
 polyhedron_mesh = meshio.Mesh(
     numpy.array(
-        [  # Three layers of a unit square
+        [  # Two layers of a unit square
             [0.0, 0.0, 0.0],
             [1.0, 0.0, 0.0],
             [1.0, 1.0, 0.0],
@@ -244,7 +244,7 @@ polyhedron_mesh = meshio.Mesh(
             [0.0, 1.0, 1.0],
         ]
     ),
-    [  # Split the lower cube into tets and pyramids. The upper cube is hexahedron
+    [  # Split the cube into tets and pyramids.
         ("polyhedron4", numpy.array([[1, 2, 5, 7], [2, 5, 6, 7]])),  # two tets
         (
             "polyhedron5",

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -406,10 +406,13 @@ def write_read(writer, reader, input_mesh, atol, extension=".dat"):
     for name, data in input_mesh.field_data.items():
         assert numpy.allclose(data, mesh.field_data[name], atol=atol, rtol=0.0)
 
-    # Restore polyhedral cell-face relations so that this is available for the
-    # next test.
-    if polyhedron:
-        input_mesh.cell_data["polyhedron:faces_of_cells"] = in_foc
+    if len(input_mesh.polyhedron_faces) > 0:
+        for poly_shape, data_in in input_mesh.polyhedron_faces.items():
+            data_out = mesh.polyhedron_faces[poly_shape]
+            # Data is a list (per cell) of numpy arrays
+            for c_in, c_out in zip(data_in, data_out):
+                for face_in, face_out in zip(c_in, c_out):
+                    assert numpy.allclose(face_in, face_out, atol=atol, rtol=0.0)
 
 
 def generic_io(filename):

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -242,15 +242,10 @@ polyhedron_mesh = meshio.Mesh(
             [1.0, 0.0, 1.0],
             [1.0, 1.0, 1.0],
             [0.0, 1.0, 1.0],
-            [0.0, 0.0, 2.0],
-            [1.0, 0.0, 2.0],
-            [1.0, 1.0, 2.0],
-            [0.0, 1.0, 2.0],
         ]
     ),
     [  # Split the lower cube into tets and pyramids. The upper cube is hexahedron
         ("polyhedron4", numpy.array([[1, 2, 5, 7], [2, 5, 6, 7]])),  # two tets
-        ("hexahedron", numpy.array([[4, 5, 6, 7, 8, 9, 10, 11]])),  # unit cube
         (
             "polyhedron5",
             numpy.array([[0, 1, 2, 3, 7], [0, 1, 6, 5, 7]]),
@@ -272,7 +267,6 @@ polyhedron_mesh = meshio.Mesh(
                     numpy.array([5, 6, 7]),
                 ],
             ],
-            "hexahedron": None,
             "polyhedron5": [
                 [
                     numpy.array([0, 1, 2, 3]),  # pyramid base is a rectangle

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -251,40 +251,38 @@ polyhedron_mesh = meshio.Mesh(
             numpy.array([[0, 1, 2, 3, 7], [0, 1, 6, 5, 7]]),
         ),  # two pyramids
     ],
-    cell_data={
-        "polyhedron:faces_of_cells": {
-            "polyhedron4": [
-                [
-                    numpy.array([1, 2, 5]),
-                    numpy.array([1, 2, 7]),
-                    numpy.array([1, 5, 7]),
-                    numpy.array([2, 5, 7]),
-                ],
-                [
-                    numpy.array([2, 5, 6]),
-                    numpy.array([2, 6, 7]),
-                    numpy.array([2, 5, 7]),
-                    numpy.array([5, 6, 7]),
-                ],
+    polyhedron_faces={
+        "polyhedron4": [
+            [
+                numpy.array([1, 2, 5]),
+                numpy.array([1, 2, 7]),
+                numpy.array([1, 5, 7]),
+                numpy.array([2, 5, 7]),
             ],
-            "polyhedron5": [
-                [
-                    numpy.array([0, 1, 2, 3]),  # pyramid base is a rectangle
-                    numpy.array([0, 1, 7]),
-                    numpy.array([1, 2, 7]),
-                    numpy.array([2, 3, 7]),
-                    numpy.array([3, 0, 7]),
-                ],
-                [
-                    numpy.array([0, 1, 6]),  # pyramid base split in two triangles
-                    numpy.array([0, 6, 7]),
-                    numpy.array([0, 1, 5]),
-                    numpy.array([0, 5, 7]),
-                    numpy.array([5, 6, 7]),
-                    numpy.array([1, 5, 6]),
-                ],
+            [
+                numpy.array([2, 5, 6]),
+                numpy.array([2, 6, 7]),
+                numpy.array([2, 5, 7]),
+                numpy.array([5, 6, 7]),
             ],
-        }
+        ],
+        "polyhedron5": [
+            [
+                numpy.array([0, 1, 2, 3]),  # pyramid base is a rectangle
+                numpy.array([0, 1, 7]),
+                numpy.array([1, 2, 7]),
+                numpy.array([2, 3, 7]),
+                numpy.array([3, 0, 7]),
+            ],
+            [
+                numpy.array([0, 1, 6]),  # pyramid base split in two triangles
+                numpy.array([0, 6, 7]),
+                numpy.array([0, 1, 5]),
+                numpy.array([0, 5, 7]),
+                numpy.array([5, 6, 7]),
+                numpy.array([1, 5, 6]),
+            ],
+        ],
     },
 )
 
@@ -372,31 +370,6 @@ def write_read(writer, reader, input_mesh, atol, extension=".dat"):
         assert numpy.allclose(
             input_mesh.point_data[key], mesh.point_data[key], atol=atol, rtol=0.0
         )
-
-    # The cell-face relations for polyhedral cells do not fit with the standard
-    # format for cell-data. Do a special test for this part.
-    polyhedron = False
-    if "polyhedron:faces_of_cells" in input_mesh.cell_data.keys():
-        polyhedron = True
-        # Pop the information so that it is not checked with standard testing
-        # of cell-data below (it will fail). The relations for input_mesh will
-        # be restored at the end of this function.
-        in_foc = input_mesh.cell_data.pop("polyhedron:faces_of_cells")
-        out_foc = mesh.cell_data.pop("polyhedron:faces_of_cells")
-        # Loop over polyhedra with different number of faces
-        for key, in_val in in_foc.items():
-            out_val = out_foc.pop(key)
-            if len(key) < 10 or key[:10] != "polyhedron":
-                continue
-            # Checks
-            assert len(in_val) == len(out_val)
-            for in_cell, out_cell in zip(in_val, out_val):
-                assert len(in_cell) == len(out_cell)
-                for in_face, out_face in zip(in_cell, out_cell):
-                    assert numpy.allclose(in_face, out_face)
-
-        # There should be no keys in out_foc that were not in in_foc
-        assert len(out_foc) == 0
 
     for name, cell_type_data in input_mesh.cell_data.items():
         for d0, d1 in zip(cell_type_data, mesh.cell_data[name]):


### PR DESCRIPTION
## Background
The current vtu filter for polyhedron cells is not compatible with the specification of the vtu format. The error was introduced (by me) in a5f59bb.

## Changes
* The vtu polyhedron filter requires, for each cell, the nodes of each of the cell's faces. This is implemented as a list of numpy arrays. 
* Reading vtu files with general and varying number of faces per cell and nodes per face, is complex compared to more standardized cases. The extensions are (mainly) confined to specific blocks of code, which should not need to be touched for changes to other grid types etc. At a few points, this localization led to slightly more complex code, but I think it is worth it.

## Main problem with the presented solution
The list of cell-faces has, from what I can see, no natural placement in the Mesh data structure. I tried to put it as cell_data, but this breaks the convention that cell_data is numpy arrays. This lead to all kind of trouble - for a glaring example see the changes to helpers.py, function write_read(). 

My preferred solution would be to introduce a new dictionary on the top level of the Mesh class (name: cell_faces?), and move the information there. This should have no impact on the rest of the code base (except that the ugly hack in the test function can be moved to a subfunction), but it will significantly reduce the entropy of the affected parts of the vtu filter. On a wider level, a dedicated field may be useful for other grid formats as well. However, I thought it best to first present a solution with less impacts on the fundamentals - I assume you try to be restrictive with changes to the Mesh class. 

Should you be willing to introduce such a new top-level field, I can take care of implementation (should be easy), and include it in this PR. I do not have oversight of all other grid formats supported by meshio, but from what I can tell, no changes outside Mesh and vtu are needed.

## Other comments
* The naming convention for polyhedron cell blocks is now explicitly set as polyhedron{number_of_nodes_per_cell} (it could have been faces per cell).
* The filter can handle polyhedra with different number of nodes, but not combinations of polyhedra with other types of cells. It should not be too difficult to implement, but the preferred solution in this case is to represent all cells as polyhedra.

