### PR TITLE
factor out _read_end_block in all Gmsh MSH

### DIFF
--- a/meshio/gmsh/_gmsh22.py
+++ b/meshio/gmsh/_gmsh22.py
@@ -10,12 +10,12 @@ from .._common import cell_data_from_raw, num_nodes_per_cell, raw_from_cell_data
 from .._exceptions import ReadError, WriteError
 from .._mesh import CellBlock, Mesh
 from .common import (
+    _fast_forward_to_end_block,
     _gmsh_to_meshio_order,
     _gmsh_to_meshio_type,
     _meshio_to_gmsh_order,
     _meshio_to_gmsh_type,
     _read_data,
-    _read_end_block,
     _read_physical_names,
     _write_data,
     _write_physical_names,
@@ -61,7 +61,7 @@ def read_buffer(f, is_ascii, data_size):
         elif environ == "ElementData":
             _read_data(f, "ElementData", cell_data_raw, data_size, is_ascii)
         else:
-            _read_end_block(f, environ)
+            _fast_forward_to_end_block(f, environ)
 
     if has_additional_tag_data:
         logging.warning("The file contains tag data that couldn't be processed.")
@@ -109,7 +109,7 @@ def _read_nodes(f, is_ascii, data_size):
         points = numpy.ascontiguousarray(data["x"])
         point_tags = data["index"]
 
-    _read_end_block(f, "Nodes")
+    _fast_forward_to_end_block(f, "Nodes")
     return points, point_tags
 
 
@@ -132,7 +132,7 @@ def _read_cells(f, cells, point_tags, is_ascii):
     for ic, (ct, cd) in enumerate(cells):
         cells[ic] = (ct, remap[cd])
 
-    _read_end_block(f, "Elements")
+    _fast_forward_to_end_block(f, "Elements")
 
     # restrict to the standard two data items (physical, geometrical)
     output_cell_tags = {}
@@ -250,7 +250,7 @@ def _read_periodic(f):
         slave_master = numpy.array(slave_master, dtype=c_int).reshape(-1, 2)
         slave_master -= 1  # Subtract one, Python is 0-based
         periodic.append([edim, (stag, mtag), affine, slave_master])
-    _read_end_block(f, "Periodic")
+    _fast_forward_to_end_block(f, "Periodic")
     return periodic
 
 

--- a/meshio/gmsh/_gmsh22.py
+++ b/meshio/gmsh/_gmsh22.py
@@ -10,12 +10,12 @@ from .._common import cell_data_from_raw, num_nodes_per_cell, raw_from_cell_data
 from .._exceptions import ReadError, WriteError
 from .._mesh import CellBlock, Mesh
 from .common import (
-    _read_end_block,
     _gmsh_to_meshio_order,
     _gmsh_to_meshio_type,
     _meshio_to_gmsh_order,
     _meshio_to_gmsh_type,
     _read_data,
+    _read_end_block,
     _read_physical_names,
     _write_data,
     _write_physical_names,

--- a/meshio/gmsh/_gmsh40.py
+++ b/meshio/gmsh/_gmsh40.py
@@ -16,12 +16,12 @@ from .._common import (
 from .._exceptions import ReadError, WriteError
 from .._mesh import CellBlock, Mesh
 from .common import (
+    _fast_forward_to_end_block,
     _gmsh_to_meshio_order,
     _gmsh_to_meshio_type,
     _meshio_to_gmsh_order,
     _meshio_to_gmsh_type,
     _read_data,
-    _read_end_block,
     _read_physical_names,
     _write_data,
     _write_physical_names,
@@ -76,7 +76,7 @@ def read_buffer(f, is_ascii, data_size):
             # $Comments/$EndComments section.
             # ```
             # skip environment
-            _read_end_block(f, environ)
+            _fast_forward_to_end_block(f, environ)
 
     cell_data = cell_data_from_raw(cells, cell_data_raw)
     cell_data.update(cell_tags)
@@ -105,7 +105,7 @@ def _read_entities(f, is_ascii, data_size):
             if d > 0:  # discard tagBREP{Vert,Curve,Surfaces}
                 num_BREP = int(fromfile(f, c_ulong, 1)[0])
                 fromfile(f, c_int, num_BREP)
-    _read_end_block(f, "Entities")
+    _fast_forward_to_end_block(f, "Entities")
     return physical_tags
 
 
@@ -153,7 +153,7 @@ def _read_nodes(f, is_ascii, data_size):
         if line != "\n":
             raise ReadError()
 
-    _read_end_block(f, "Nodes")
+    _fast_forward_to_end_block(f, "Nodes")
     return points, tags
 
 
@@ -179,7 +179,7 @@ def _read_elements(f, point_tags, physical_tags, is_ascii, data_size):
         else:
             data.append((physical_tags[dim_entity][tag_entity], tag_entity, tpe, d))
 
-    _read_end_block(f, "Elements")
+    _fast_forward_to_end_block(f, "Elements")
 
     # The msh4 elements array refers to the nodes by their tag, not the index. All other
     # mesh formats use the index, which is far more efficient, too. Hence,
@@ -238,7 +238,7 @@ def _read_periodic(f, is_ascii):
         slave_master = slave_master - 1  # Subtract one, Python is 0-based
         periodic.append([edim, (stag, mtag), affine, slave_master])
 
-    _read_end_block(f, "Periodic")
+    _fast_forward_to_end_block(f, "Periodic")
     return periodic
 
 

--- a/meshio/gmsh/_gmsh41.py
+++ b/meshio/gmsh/_gmsh41.py
@@ -16,12 +16,12 @@ from .._common import (
 from .._exceptions import ReadError, WriteError
 from .._mesh import CellBlock, Mesh
 from .common import (
+    _fast_forward_to_end_block,
     _gmsh_to_meshio_order,
     _gmsh_to_meshio_type,
     _meshio_to_gmsh_order,
     _meshio_to_gmsh_type,
     _read_data,
-    _read_end_block,
     _read_physical_names,
     _write_data,
     _write_physical_names,
@@ -84,7 +84,7 @@ def read_buffer(f, is_ascii, data_size):
             # $Comments/$EndComments section.
             # ```
             # skip environment
-            _read_end_block(f, environ)
+            _fast_forward_to_end_block(f, environ)
 
     if cells is None:
         raise ReadError("$Element section not found.")
@@ -118,7 +118,7 @@ def _read_entities(f, is_ascii, data_size):
                 (num_BREP_,) = fromfile(f, c_size_t, 1)
                 fromfile(f, c_int, num_BREP_)
 
-    _read_end_block(f, "Entities")
+    _fast_forward_to_end_block(f, "Entities")
     return physical_tags
 
 
@@ -157,7 +157,7 @@ def _read_nodes(f, is_ascii, data_size):
         points[ixx] = fromfile(f, c_double, num_nodes * 3).reshape((num_nodes, 3))
         idx += num_nodes
 
-    _read_end_block(f, "Nodes")
+    _fast_forward_to_end_block(f, "Nodes")
     return points, tags
 
 
@@ -200,7 +200,7 @@ def _read_elements(f, point_tags, physical_tags, is_ascii, data_size, field_data
         else:
             data.append((physical_tags[dim_entity][tag_entity], tag_entity, tpe, d))
 
-    _read_end_block(f, "Elements")
+    _fast_forward_to_end_block(f, "Elements")
 
     # Inverse point tags
     inv_tags = numpy.full(numpy.max(point_tags) + 1, -1, dtype=int)
@@ -248,7 +248,7 @@ def _read_periodic(f, is_ascii, data_size):
         slave_master = slave_master - 1  # Subtract one, Python is 0-based
         periodic.append([edim, (stag, mtag), affine, slave_master])
 
-    _read_end_block(f, "Periodic")
+    _fast_forward_to_end_block(f, "Periodic")
     return periodic
 
 

--- a/meshio/gmsh/common.py
+++ b/meshio/gmsh/common.py
@@ -9,7 +9,7 @@ c_int = numpy.dtype("i")
 c_double = numpy.dtype("d")
 
 
-def _read_end_block(f, block):
+def _fast_forward_to_end_block(f, block):
     """fast-forward to end of block"""
     # See also https://github.com/nschloe/pygalmesh/issues/34
 
@@ -32,7 +32,7 @@ def _read_physical_names(f, field_data):
         key = line[2]
         value = numpy.array(line[1::-1], dtype=int)
         field_data[key] = value
-    _read_end_block(f, "PhysicalNames")
+    _fast_forward_to_end_block(f, "PhysicalNames")
 
 
 def _read_data(f, tag, data_dict, data_size, is_ascii):
@@ -65,7 +65,7 @@ def _read_data(f, tag, data_dict, data_size, is_ascii):
             raise ReadError()
         data = numpy.ascontiguousarray(data["values"])
 
-    _read_end_block(f, tag)
+    _fast_forward_to_end_block(f, tag)
 
     # The gmsh format cannot distingiush between data of shape (n,) and (n, 1).
     # If shape[1] == 1, cut it off.

--- a/meshio/gmsh/common.py
+++ b/meshio/gmsh/common.py
@@ -9,6 +9,21 @@ c_int = numpy.dtype("i")
 c_double = numpy.dtype("d")
 
 
+def _read_end_block(f, block):
+    """fast-forward to end of block"""
+    # See also https://github.com/nschloe/pygalmesh/issues/34
+
+    for line in f:
+        try:
+            line = line.decode("utf-8")
+        except UnicodeDecodeError:
+            pass
+        if line == f"$End{block}\n":
+            break
+    else:
+        logging.warning(f"${block} not closed by $End{block}.")
+
+
 def _read_physical_names(f, field_data):
     line = f.readline().decode("utf-8")
     num_phys_names = int(line)
@@ -17,9 +32,7 @@ def _read_physical_names(f, field_data):
         key = line[2]
         value = numpy.array(line[1::-1], dtype=int)
         field_data[key] = value
-    line = f.readline().decode("utf-8")
-    if line.strip() != "$EndPhysicalNames":
-        raise ReadError()
+    _read_end_block(f, "PhysicalNames")
 
 
 def _read_data(f, tag, data_dict, data_size, is_ascii):
@@ -52,10 +65,7 @@ def _read_data(f, tag, data_dict, data_size, is_ascii):
             raise ReadError()
         data = numpy.ascontiguousarray(data["values"])
 
-    # fast forward to $End{tag}
-    line = f.readline().decode("utf-8")
-    while line.strip() != f"$End{tag}":
-        line = f.readline().decode("utf-8")
+    _read_end_block(f, tag)
 
     # The gmsh format cannot distingiush between data of shape (n,) and (n, 1).
     # If shape[1] == 1, cut it off.

--- a/meshio/gmsh/main.py
+++ b/meshio/gmsh/main.py
@@ -4,6 +4,7 @@ import struct
 from .._exceptions import ReadError, WriteError
 from .._helpers import register
 from . import _gmsh22, _gmsh40, _gmsh41
+from .common import _read_end_block
 
 # Some mesh files out there have the version specified as version "2" when it really is
 # "2.2". Same with "4" vs "4.1".
@@ -26,8 +27,7 @@ def read_buffer(f):
 
     # skip any $Comments/$EndComments sections
     while line == "$Comments":
-        while line != "$EndComments":
-            line = f.readline().decode("utf-8").strip()
+        _read_end_block(f, "Comments")
         line = f.readline().decode("utf-8").strip()
 
     if line != "$MeshFormat":
@@ -79,10 +79,7 @@ def _read_header(f):
         one = f.read(struct.calcsize("i"))
         if struct.unpack("i", one)[0] != 1:
             raise ReadError()
-    # Fast forward to $EndMeshFormat
-    line = f.readline().decode("utf-8")
-    while line.strip() != "$EndMeshFormat":
-        line = f.readline().decode("utf-8")
+    _read_end_block(f, "MeshFormat")
     return fmt_version, data_size, is_ascii
 
 

--- a/meshio/gmsh/main.py
+++ b/meshio/gmsh/main.py
@@ -4,7 +4,7 @@ import struct
 from .._exceptions import ReadError, WriteError
 from .._helpers import register
 from . import _gmsh22, _gmsh40, _gmsh41
-from .common import _read_end_block
+from .common import _fast_forward_to_end_block
 
 # Some mesh files out there have the version specified as version "2" when it really is
 # "2.2". Same with "4" vs "4.1".
@@ -27,7 +27,7 @@ def read_buffer(f):
 
     # skip any $Comments/$EndComments sections
     while line == "$Comments":
-        _read_end_block(f, "Comments")
+        _fast_forward_to_end_block(f, "Comments")
         line = f.readline().decode("utf-8").strip()
 
     if line != "$MeshFormat":
@@ -79,7 +79,7 @@ def _read_header(f):
         one = f.read(struct.calcsize("i"))
         if struct.unpack("i", one)[0] != 1:
             raise ReadError()
-    _read_end_block(f, "MeshFormat")
+    _fast_forward_to_end_block(f, "MeshFormat")
     return fmt_version, data_size, is_ascii
 
 


### PR DESCRIPTION
In #914, new code was merged to fast-forward to `$EndElements` in MSH 2.2, but it's a general feature of all Gmsh MSH formats, so here it's factored into a module function `gmsh.common._read_end_block` and used everywhere.

There was some inconsistency in whether failure to find the required ending raised a `ReadError`; here I've settled on warning but if its thought that being strict is more helpful, I don't mind that being enforced instead.

I didn't look up nschloe/pygalmesh#34 and the `UnicodeDecodeError` but just applied that everywhere too.
