### PR TITLE
Another attempt at adding support for "*include" statements in abaqus

### DIFF
--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -2,8 +2,8 @@
 I/O for Abaqus inp files.
 """
 import io
-import re
 import pathlib
+import re
 
 import numpy
 
@@ -97,19 +97,21 @@ meshio_to_abaqus_type = {v: k for k, v in abaqus_to_meshio_type.items()}
 
 
 def read_w_includes(inp_path):
-    re_in = re.compile(r'\*Include,\s*input=(.*?)$', re.IGNORECASE | re.MULTILINE | re.DOTALL)
+    re_in = re.compile(
+        r"\*Include,\s*input=(.*?)$", re.IGNORECASE | re.MULTILINE | re.DOTALL
+    )
     bulk_repl = dict()
     with open_file(inp_path, "r") as f:
         bulk_str = f.read()
 
     for m in re_in.finditer(bulk_str):
         search_key = m.group(0)
-        incl_ref = m.group(1).replace('\\', '/')
+        incl_ref = m.group(1).replace("\\", "/")
         # The include ref can be absolute or relative to .inp file. Will check for both
         if pathlib.Path(incl_ref).exists() is False:
             cd = pathlib.Path(inp_path).parents[0]
             incl_ref = cd / incl_ref
-        with open(pathlib.Path(incl_ref).absolute(), 'r') as d:
+        with open(pathlib.Path(incl_ref).absolute(), "r") as d:
             bulk_repl[search_key] = d.read()
 
     for key, val in bulk_repl.items():
@@ -191,7 +193,7 @@ def read_buffer(f):
                         cell_sets[name].append(cell_sets_element[set_name])
                     else:
                         raise ReadError(f"Unknown cell set '{set_name}'")
-        elif keyword == 'INCLUDE':
+        elif keyword == "INCLUDE":
             return read_w_includes(f.name)
         else:
             # There are just too many Abaqus keywords to explicitly skip them.

--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -295,10 +295,10 @@ def merge(
 
     if len(points) > 0:
         new_point_id = points.shape[0]
-        new_cell_id = len(cells) + 1
+        # new_cell_id = len(cells) + 1
         points = numpy.concatenate([points, ext_points])
     else:
-        new_cell_id = 0
+        # new_cell_id = 0
         new_point_id = 0
         points = ext_points
 

--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -2,8 +2,8 @@
 I/O for Abaqus inp files.
 """
 import io
-import os
 import re
+import pathlib
 
 import numpy
 
@@ -104,7 +104,12 @@ def read_w_includes(inp_path):
 
     for m in re_in.finditer(bulk_str):
         search_key = m.group(0)
-        with open(os.path.join(os.path.dirname(inp_path), m.group(1)), 'r') as d:
+        incl_ref = m.group(1).replace('\\', '/')
+        # The include ref can be absolute or relative to .inp file. Will check for both
+        if pathlib.Path(incl_ref).exists() is False:
+            cd = pathlib.Path(inp_path).parents[0]
+            incl_ref = cd / incl_ref
+        with open(pathlib.Path(incl_ref).absolute(), 'r') as d:
             bulk_repl[search_key] = d.read()
 
     for key, val in bulk_repl.items():

--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -103,6 +103,7 @@ def read(filename):
 
 def read_buffer(f):
     # Initialize the optional data fields
+    points = []
     cells = []
     cell_ids = []
     point_sets = {}
@@ -113,20 +114,10 @@ def read_buffer(f):
     cell_data = {}
     point_data = {}
 
-    parent_file_gen = None
-
     line = f.readline()
     while True:
         if not line:  # EOF
-            if parent_file_gen is not None:
-                f.close()
-                f = parent_file_gen
-                parent_file_gen = None
-                line = f.readline()
-                if not line:
-                    break
-            else:
-                break
+            break
 
         # Comments
         if line.startswith("**"):
@@ -178,16 +169,29 @@ def read_buffer(f):
                     else:
                         raise ReadError(f"Unknown cell set '{set_name}'")
         elif keyword == "INCLUDE":
-            # Get absolute path to referred input file
-            incl_ref = line.split("=")[-1].rstrip().replace("\\", "/")
-            if pathlib.Path(incl_ref).exists() is False:
-                cd = pathlib.Path(f.name).parents[0]
-                incl_ref = cd / incl_ref
-            # Store current generator in temp object parent_file_gen
-            parent_file_gen = f
-            f = open(pathlib.Path(incl_ref).absolute(), "r")
+            # Splitting line to get external input file path (example: *INCLUDE,INPUT=wInclude_bulk.inp)
+            ext_input_file = pathlib.Path(line.split("=")[-1].strip())
+            if ext_input_file.exists() is False:
+                cd = pathlib.Path(f.name).parent
+                ext_input_file = cd / ext_input_file
+
+            # Read contents from external input file into mesh object
+            out = read(ext_input_file)
+
+            # Merge contents of external file only if it is containing mesh data
+            if len(out.points) > 0:
+                points, cells = merge(
+                    out,
+                    points,
+                    cells,
+                    point_data,
+                    cell_data,
+                    field_data,
+                    point_sets,
+                    cell_sets,
+                )
+
             line = f.readline()
-            # return read_w_includes(f.name)
         else:
             # There are just too many Abaqus keywords to explicitly skip them.
             line = f.readline()
@@ -269,6 +273,56 @@ def _read_cells(f, params_map, point_ids):
     )
 
     return cell_type, numpy.array(cells), cell_ids, cell_sets, line
+
+
+def merge(
+    mesh, points, cells, point_data, cell_data, field_data, point_sets, cell_sets
+):
+    """
+    Merge Mesh object into existing containers for points, cells, sets, etc..
+
+    :param mesh:
+    :param points:
+    :param cells:
+    :param point_data:
+    :param cell_data:
+    :param field_data:
+    :param point_sets:
+    :param cell_sets:
+    :type mesh: Mesh
+    """
+    ext_points = numpy.array([p for p in mesh.points])
+
+    if len(points) > 0:
+        new_point_id = points.shape[0]
+        new_cell_id = len(cells) + 1
+        points = numpy.concatenate([points, ext_points])
+    else:
+        new_cell_id = 0
+        new_point_id = 0
+        points = ext_points
+
+    cnt = 0
+    for c in mesh.cells:
+        new_data = numpy.array([d + new_point_id for d in c.data])
+        cells.append(CellBlock(c.type, new_data))
+        cnt += 1
+
+    # The following aren't currently included in the abaqus parser, and are therefore excluded?
+    # point_data.update(mesh.point_data)
+    # cell_data.update(mesh.cell_data)
+    # field_data.update(mesh.field_data)
+
+    # Update point and cell sets to account for change in cell and point ids
+    for key, val in mesh.point_sets.items():
+        point_sets[key] = [x + new_point_id for x in val]
+
+    # Todo: Add support for merging cell sets
+    # cellblockref = [[] for i in range(cnt-new_cell_id)]
+    # for key, val in mesh.cell_sets.items():
+    #     cell_sets[key] = cellblockref + [numpy.array([x for x in val[0]])]
+
+    return points, cells
 
 
 def get_param_map(word, required_keys=None):

--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -179,7 +179,7 @@ def read_buffer(f):
                         raise ReadError(f"Unknown cell set '{set_name}'")
         elif keyword == "INCLUDE":
             # Get absolute path to referred input file
-            incl_ref = line.lower().split("input=")[-1].rstrip().replace("\\", "/")
+            incl_ref = line.split("=")[-1].rstrip().replace("\\", "/")
             if pathlib.Path(incl_ref).exists() is False:
                 cd = pathlib.Path(f.name).parents[0]
                 incl_ref = cd / incl_ref

--- a/test/meshes/abaqus/wInclude_bulk.inp
+++ b/test/meshes/abaqus/wInclude_bulk.inp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26ddc51edbe37e3067a9d0add9bb691363df19b485e0b6a8e5bfd4a67dc4507f
+size 483

--- a/test/meshes/abaqus/wInclude_main.inp
+++ b/test/meshes/abaqus/wInclude_main.inp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7001a13301c86e4dfafff29b554cc1dbbc025f3f03c26f2609fdc248481d3e6e
+size 202

--- a/test/test_abaqus.py
+++ b/test/test_abaqus.py
@@ -36,6 +36,7 @@ def test(mesh):
         ("UUea.inp", 4950.0, 50, 10),
         ("nle1xf3c.inp", 32.215275528, 12, 3),
         ("element_elset.inp", 6.0, 2, 3),
+        ("wInclude_main.inp", 1.5, 2, 1)
     ],
 )
 def test_reference_file(filename, ref_sum, ref_num_cells, ref_num_cell_sets):

--- a/test/test_abaqus.py
+++ b/test/test_abaqus.py
@@ -36,7 +36,7 @@ def test(mesh):
         ("UUea.inp", 4950.0, 50, 10),
         ("nle1xf3c.inp", 32.215275528, 12, 3),
         ("element_elset.inp", 6.0, 2, 3),
-        ("wInclude_main.inp", 1.5, 2, 1)
+        ("wInclude_main.inp", 1.5, 2, 1),
     ],
 )
 def test_reference_file(filename, ref_sum, ref_num_cells, ref_num_cell_sets):

--- a/test/test_abaqus.py
+++ b/test/test_abaqus.py
@@ -36,7 +36,7 @@ def test(mesh):
         ("UUea.inp", 4950.0, 50, 10),
         ("nle1xf3c.inp", 32.215275528, 12, 3),
         ("element_elset.inp", 6.0, 2, 3),
-        ("wInclude_main.inp", 1.5, 2, 1),
+        ("wInclude_main.inp", 1.5, 2, 0),
     ],
 )
 def test_reference_file(filename, ref_sum, ref_num_cells, ref_num_cell_sets):


### PR DESCRIPTION
Here is a redo of pull request #920. Now I have left the original implementation as is for input files not containing the *include flag. 

The current implementation does however still read the files in memory and assembles the included files into 1 input file before it parses it back into the read_buffer using StringIO. So its an improvement over my last suggestion (as now it does not break anything), but not as efficient as it probably could be.