### PR TITLE
Export gmsh entities

### DIFF
--- a/meshio/gmsh/_gmsh41.py
+++ b/meshio/gmsh/_gmsh41.py
@@ -441,6 +441,9 @@ def _write_entities(fh, cells, cell_data, cell_sets, point_data, binary):
 
     # Write number of entities per dimension
     num_occ = numpy.bincount(node_dim_tags[:, 0], minlength=4)
+    if num_occ.size > 4:
+        raise ValueError("Encountered entity with dimension > 3")
+
     if binary:
         num_occ.astype(c_size_t).tofile(fh)
     else:
@@ -469,6 +472,10 @@ def _write_entities(fh, cells, cell_data, cell_sets, point_data, binary):
         matching_cell_block = numpy.where(
             numpy.logical_and(cell_dim_tags[:, 0] == dim, cell_dim_tags[:, 1] == tag)
         )[0]
+        if matching_cell_block.size > 1:
+            # It is not 100% clear if this is not permissible, but the current
+            # implementation for sure does not allow it.
+            raise ValueError("Encountered non-unique CellBlock dim_tag")
 
         # The information to be written varies according to entity dimension,
         # whether entity has a physical tag, and between ascii and binary.

--- a/meshio/gmsh/_gmsh41.py
+++ b/meshio/gmsh/_gmsh41.py
@@ -562,7 +562,6 @@ def _write_nodes(fh, points, cells, point_data, float_fmt, binary):
     max_tag = n
     is_parametric = 0
 
-
     # If node entity and dimension is available, we make a list of unique
     # combinations thereof, and a map from the full node set to the unique
     # set.

--- a/meshio/gmsh/_gmsh41.py
+++ b/meshio/gmsh/_gmsh41.py
@@ -124,8 +124,8 @@ def _read_entities(f, is_ascii, data_size):
 
     fromfile = partial(numpy.fromfile, sep=" " if is_ascii else "")
     c_size_t = _size_type(data_size)
-    physical_tags = tuple({} for _ in range(4))  # dims 0, 1, 2, 3
-    bounding_entities = tuple({} for _ in range(4))
+    physical_tags = ({}, {}, {}, {})
+    bounding_entities = ({}, {}, {}, {})
     number = fromfile(f, c_size_t, 4)  # dims 0, 1, 2, 3
     for d, n in enumerate(number):
         for _ in range(n):

--- a/meshio/gmsh/_gmsh41.py
+++ b/meshio/gmsh/_gmsh41.py
@@ -159,8 +159,8 @@ def _read_nodes(f, is_ascii, data_size):
 
     points = numpy.empty((total_num_nodes, 3), dtype=float)
     tags = numpy.empty(total_num_nodes, dtype=int)
-    entity_of_nodes = numpy.empty_like(tags)
-    entity_dimension = numpy.empty_like(tags)
+    dim_tags = numpy.empty((total_num_nodes, 2), dtype=int)
+
     # To save the entity block id for each node, initialize an array here,
     # populate it with num_nodes
     idx = 0
@@ -186,14 +186,11 @@ def _read_nodes(f, is_ascii, data_size):
         points[ixx] = fromfile(f, c_double, num_nodes * 3).reshape((num_nodes, 3))
 
         # Entity tag and entity dimension of the nodes. Stored as point-data.
-        entity_of_nodes[ixx] = entity_tag
-        entity_dimension[ixx] = dim
+        dim_tags[ixx, 0] = dim
+        dim_tags[ixx, 1] = entity_tag
         idx += num_nodes
 
     _fast_forward_to_end_block(f, "Nodes")
-
-    # Entity information for nodes is stored as point data, as an nx2 array
-    dim_tags = numpy.vstack((entity_dimension, entity_of_nodes)).T
 
     return points, tags, dim_tags
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -332,7 +332,8 @@ def write_read(writer, reader, input_mesh, atol, extension=".dat"):
     # To avoid errors from sorted (below), specify the key as first cell type
     # then index of the first point of the first cell. This may still lead to
     # comparison of what should be different blocks, but chances seem low.
-    cell_sorter = lambda cell: (cell.type, cell.data[0, 0])
+    def cell_sorter(cell):
+        return (cell.type, cell.data[0, 0])
 
     # to make sure we are testing same type of cells we sort the list
     for cells0, cells1 in zip(

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -355,9 +355,12 @@ def write_read(writer, reader, input_mesh, atol, extension=".dat"):
     for name, data in input_mesh.field_data.items():
         assert numpy.allclose(data, mesh.field_data[name], atol=atol, rtol=0.0)
 
-    # Test of cell sets (assumed to be a list of numpy arrays)
-    for name1, data in input_mesh.cell_sets.items():
-        data2 = mesh.cell_sets[name1]
+    # Test of cell sets (assumed to be a list of numpy arrays),
+    for name, data in input_mesh.cell_sets.items():
+        # Skip the test if the key is not in the read cell set
+        if name not in mesh.cell_sets.keys():
+            continue
+        data2 = mesh.cell_sets[name]
         for var1, var2 in zip(data, data2):
             assert numpy.allclose(var1, var2, atol=atol, rtol=0.0)
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -370,7 +370,11 @@ def write_read(writer, reader, input_mesh, atol, extension=".dat"):
     # then index of the first point of the first cell. This may still lead to
     # comparison of what should be different blocks, but chances seem low.
     def cell_sorter(cell):
-        return (cell.type, cell.data[0, 0])
+        if cell.type[:10] == "polyhedron":
+            # Polyhedra blocks should be well enough distinguished by their type
+            return cell.type
+        else:
+            return (cell.type, cell.data[0, 0])
 
     # to make sure we are testing same type of cells we sort the list
     for cells0, cells1 in zip(

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -355,6 +355,12 @@ def write_read(writer, reader, input_mesh, atol, extension=".dat"):
     for name, data in input_mesh.field_data.items():
         assert numpy.allclose(data, mesh.field_data[name], atol=atol, rtol=0.0)
 
+    # Test of cell sets (assumed to be a list of numpy arrays)
+    for name1, data in input_mesh.cell_sets.items():
+        data2 = mesh.cell_sets[name1]
+        for var1, var2 in zip(data, data2):
+            assert numpy.allclose(var1, var2, atol=atol, rtol=0.0)
+
 
 def generic_io(filename):
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -329,8 +329,15 @@ def write_read(writer, reader, input_mesh, atol, extension=".dat"):
     n = in_mesh.points.shape[1]
     assert numpy.allclose(in_mesh.points, mesh.points[:, :n], atol=atol, rtol=0.0)
 
+    # To avoid errors from sorted (below), specify the key as first cell type
+    # then index of the first point of the first cell. This may still lead to
+    # comparison of what should be different blocks, but chances seem low.
+    cell_sorter = lambda cell: (cell.type, cell.data[0, 0])
+
     # to make sure we are testing same type of cells we sort the list
-    for cells0, cells1 in zip(sorted(input_mesh.cells), sorted(mesh.cells)):
+    for cells0, cells1 in zip(
+        sorted(input_mesh.cells, key=cell_sorter), sorted(mesh.cells, key=cell_sorter)
+    ):
         assert cells0.type == cells1.type, f"{cells0.type} != {cells1.type}"
         assert numpy.array_equal(cells0.data, cells1.data)
 


### PR DESCRIPTION
## Summary
Expansions of the gmsh filter (only format _41):
* Gmsh entity tags are read and written. This necessitated storage of entity tags for nodes and cells.
* With this extension, it is also possible to write .msh files with more than one cell block, provided the necessary entity tags are present in the Mesh. The existing functionality (deal with a single cell block, no need to care about tags) is preserved as an alternative.
* Boundary entities (which 0d entities form the boundary of a 1d entity etc.) can now be read and written.

## Testing
I have not written any tests for the added functionality: This would require tailored setups, which breaks with the standard approach to meshio testing (simple setups, throw a lot of grids on it). I will of course write tests if requested, but I would welcome some guidance on how to set up such tests. 

For clarity, the testing during development focused on a .msh files with somewhat general combinations of entities in different dimensions, different physical objects etc. I can of course share this for use as a reference file in testing, if you are interested.