### PR TITLE
nastran writer: use fixed length format

### DIFF
--- a/meshio/nastran/_nastran.py
+++ b/meshio/nastran/_nastran.py
@@ -227,6 +227,10 @@ def print_scientific(value, length=16):
     return field
 
 
+def _float_rstrip(x, n=8):
+    return f"{x:f}".rstrip("0")[:n]
+
+
 # There are two basic categories of input data formats in NX Nastran:
 #
 #     "Free" format data, in which the data fields are simply separated by commas. This type of data is known as free field data.
@@ -243,7 +247,7 @@ def write(filename, mesh, point_format="fixed-large", cell_format="fixed-small")
         float_fmt = print_scientific
     elif point_format == "fixed-small":
         grid_fmt = "GRID    {:<8d}{:<8s}{:>8s}{:>8s}{:>8s}\n"
-        float_fmt = lambda x: f"{x:f}".rstrip("0")[:8]
+        float_fmt = _float_rstrip
     elif point_format == "fixed-large":
         grid_fmt = "GRID*   {:<16d}{:<16s}{:>16s}{:>16s}\n*       {:>16s}\n"
         float_fmt = print_scientific

--- a/meshio/nastran/_nastran.py
+++ b/meshio/nastran/_nastran.py
@@ -227,6 +227,15 @@ def print_scientific(value, length=16):
     return field
 
 
+# There are two basic categories of input data formats in NX Nastran:
+#
+#     "Free" format data, in which the data fields are simply separated by commas. This type of data is known as free field data.
+#     "Fixed" format data, in which your data must be aligned in columns of specific width. There are two subcategories of fixed format data that differ based on the size of the fixed column width:
+#         Small field format, in which a single line of data is divided into 10 fields that can contain eight characters each.
+#         Large field format, in which a single line of input is expanded into two lines The first and last fields on each line are eight columns wide, while the intermediate fields are sixteen columns wide. The large field format is useful when you need greater numerical accuracy.
+#
+# See: https://docs.plm.automation.siemens.com/data_services/resources/nxnastran/10/help/en_US/tdocExt/pdf/User.pdf
+
 def write(filename, mesh, point_format="fixed-large", cell_format="fixed-small"):
     if point_format == "free":
         grid_fmt = "GRID,{:d},{:s},{:s},{:s},{:s}\n"

--- a/meshio/nastran/_nastran.py
+++ b/meshio/nastran/_nastran.py
@@ -209,7 +209,7 @@ def print_scientific(value, length=16):
     svalue, sexponent = python_value.strip().split("e")
     exponent = int(sexponent)  # removes 0s
 
-    sign = "-" if abs(value) < 1. else "+"
+    sign = "-" if abs(value) < 1.0 else "+"
 
     # the exponent will be added later...
     sexp2 = str(exponent).strip("-+")
@@ -235,6 +235,7 @@ def print_scientific(value, length=16):
 #         Large field format, in which a single line of input is expanded into two lines The first and last fields on each line are eight columns wide, while the intermediate fields are sixteen columns wide. The large field format is useful when you need greater numerical accuracy.
 #
 # See: https://docs.plm.automation.siemens.com/data_services/resources/nxnastran/10/help/en_US/tdocExt/pdf/User.pdf
+
 
 def write(filename, mesh, point_format="fixed-large", cell_format="fixed-small"):
     if point_format == "free":

--- a/test/test_nastran.py
+++ b/test/test_nastran.py
@@ -23,7 +23,7 @@ import meshio
     ],
 )
 def test(mesh):
-    helpers.write_read(meshio.nastran.write, meshio.nastran.read, mesh, 1.0e-15)
+    helpers.write_read(meshio.nastran.write, meshio.nastran.read, mesh, 1.0e-13)
 
 
 @pytest.mark.parametrize("filename", ["cylinder.fem", "cylinder_cells_first.fem"])


### PR DESCRIPTION
Meshio Nastran writer produces files with comma separated items, called "free field format" in [1]. Unfortunately this is not accepted by my Marc Mentat 2010 (yes, a bit outdated version). So I have prepared this PR, which:

 * implements writing data in "fixed" format
 * adds new `free_format` attribute to `writer()` function to switch between "free" and "fixed" formats. The default value is `free_format=True`.
 * fixes the "free" format code - according to [1], page 28,  data cannot contain embedded blanks

Original output:
```
GRID, 1331,, -4.0000000000000002e-01, 4.0000000000000002e-01, -4.0000000000000002e-01
CHEXA, 1,, 1, 3, 360, 359, 32, 113
+, 603, 522
```
New output - free format:
```
GRID,1331,,-4.0000000000000002e-01,4.0000000000000002e-01,-4.0000000000000002e-01
CHEXA,1,,1,3,360,359,32,113
+,603,522
```
Still, I'm not sure if the line continuation, i.e. `+,`,  in the example above (free format) is correct. I can not find any comments regarding to this in [1].

[1] https://docs.plm.automation.siemens.com/data_services/resources/nxnastran/10/help/en_US/tdocExt/pdf/User.pdf