### PR TITLE
Fix duplicate material array in AVSUCD

### DIFF
--- a/meshio/avsucd/_avsucd.py
+++ b/meshio/avsucd/_avsucd.py
@@ -170,7 +170,9 @@ def write(filename, mesh):
                 "Picking {}, skipping {}.".format(key, ", ".join(other))
             )
         material = (
-            numpy.concatenate(mesh.cell_data[key]) if key else numpy.zeros(num_cells, dtype=int)
+            numpy.concatenate(mesh.cell_data[key])
+            if key
+            else numpy.zeros(num_cells, dtype=int)
         )
 
         num_node_data = [
@@ -178,7 +180,8 @@ def write(filename, mesh):
         ]
         num_cell_data = [
             1 if numpy.concatenate(v).ndim == 1 else numpy.concatenate(v).shape[1]
-            for k, v in mesh.cell_data.items() if k != key
+            for k, v in mesh.cell_data.items()
+            if k != key
         ]
         num_node_data_sum = sum(num_node_data)
         num_cell_data_sum = sum(num_cell_data)

--- a/meshio/avsucd/_avsucd.py
+++ b/meshio/avsucd/_avsucd.py
@@ -207,7 +207,7 @@ def write(filename, mesh):
 
         # Write cell data
         if num_cell_data_sum:
-            labels = list(mesh.cell_data.keys())
+            labels = [k for k in mesh.cell_data.keys() if k != key]
             data_array = numpy.column_stack(
                 [numpy.concatenate(v) for k, v in mesh.cell_data.items() if k != key]
             )

--- a/meshio/avsucd/_avsucd.py
+++ b/meshio/avsucd/_avsucd.py
@@ -161,12 +161,24 @@ def write(filename, mesh):
         # Write first line
         num_nodes = len(mesh.points)
         num_cells = sum(len(c.data) for c in mesh.cells)
+
+        # Try to find an appropriate materials array
+        key, other = _pick_first_int_data(mesh.cell_data)
+        if key and other:
+            logging.warning(
+                "AVS-UCD can only write one cell data array. "
+                "Picking {}, skipping {}.".format(key, ", ".join(other))
+            )
+        material = (
+            numpy.concatenate(mesh.cell_data[key]) if key else numpy.zeros(num_cells, dtype=int)
+        )
+
         num_node_data = [
             1 if v.ndim == 1 else v.shape[1] for v in mesh.point_data.values()
         ]
         num_cell_data = [
             1 if numpy.concatenate(v).ndim == 1 else numpy.concatenate(v).shape[1]
-            for k, v in mesh.cell_data.items()
+            for k, v in mesh.cell_data.items() if k != key
         ]
         num_node_data_sum = sum(num_node_data)
         num_cell_data_sum = sum(num_cell_data)
@@ -180,7 +192,7 @@ def write(filename, mesh):
         _write_nodes(f, mesh.points)
 
         # Write cells
-        _write_cells(f, mesh.cells, mesh.cell_data, num_cells)
+        _write_cells(f, mesh.cells, material)
 
         # Write node data
         if num_node_data_sum:
@@ -194,7 +206,7 @@ def write(filename, mesh):
         if num_cell_data_sum:
             labels = list(mesh.cell_data.keys())
             data_array = numpy.column_stack(
-                [numpy.concatenate(v) for v in mesh.cell_data.values()]
+                [numpy.concatenate(v) for k, v in mesh.cell_data.items() if k != key]
             )
             _write_data(
                 f, labels, data_array, num_cells, num_cell_data, num_cell_data_sum
@@ -206,19 +218,7 @@ def _write_nodes(f, points):
         f.write("{} {} {} {}\n".format(i + 1, x, y, z))
 
 
-def _write_cells(f, cells, cell_data, num_cells):
-    # try to find an appropriate materials array
-    key, other = _pick_first_int_data(cell_data)
-    if key and other:
-        logging.warning(
-            "AVS-UCD can only write one cell data array. "
-            "Picking {}, skipping {}.".format(key, ", ".join(other))
-        )
-    material = (
-        numpy.concatenate(cell_data[key]) if key else numpy.zeros(num_cells, dtype=int)
-    )
-
-    # Loop over cells
+def _write_cells(f, cells, material):
     i = 0
     for cell_type, v in cells:
         for cell in v[:, meshio_to_avsucd_order[cell_type]]:

--- a/test/test_avsucd.py
+++ b/test/test_avsucd.py
@@ -12,7 +12,7 @@ import meshio
         helpers.tri_quad_mesh,
         helpers.tet_mesh,
         helpers.hex_mesh,
-        helpers.add_cell_data(helpers.tri_mesh, [("a", (), int)]),
+        helpers.add_cell_data(helpers.tri_mesh, [("avsucd:material", (), int)]),
     ],
 )
 def test(mesh):

--- a/test/test_avsucd.py
+++ b/test/test_avsucd.py
@@ -12,8 +12,12 @@ import meshio
         helpers.tri_quad_mesh,
         helpers.tet_mesh,
         helpers.hex_mesh,
-        helpers.add_cell_data(helpers.tri_mesh, [("avsucd:material", (), int)]),
+        helpers.add_cell_data(
+            helpers.tri_mesh,
+            [("avsucd:material", (), int), ("a", (), float), ("b", (3,), float)],
+        ),
+        helpers.add_point_data(helpers.add_point_data(helpers.tri_mesh, 1), 3),
     ],
 )
 def test(mesh):
-    helpers.write_read(meshio.avsucd.write, meshio.avsucd.read, mesh, 1.0e-15)
+    helpers.write_read(meshio.avsucd.write, meshio.avsucd.read, mesh, 1.0e-13)


### PR DESCRIPTION
- Fixed: do not write picked material array in cell data section as it is already written as Material Id,
- Added: test 1D and 2D point and cell data arrays.