### PR TITLE
add keyword for the mesh generated from bamg

### DIFF
--- a/meshio/medit/_medit.py
+++ b/meshio/medit/_medit.py
@@ -205,7 +205,7 @@ def read_ascii_buffer(f):
 
         if items[0] == "MeshVersionFormatted":
             version = items[1]
-            dtype = {"1": c_float, "2": c_double}[version]
+            dtype = {"0": c_float, "1": c_float, "2": c_double}[version]
         elif items[0] == "Dimension":
             if len(items) >= 2:
                 dim = int(items[1])
@@ -252,6 +252,32 @@ def read_ascii_buffer(f):
             np.fromfile(
                 f, count=num_normal_at_vertices * 2, dtype=int, sep=" "
             ).reshape(num_normal_at_vertices, 2)
+        elif items[0] == "SubDomainFromMesh":
+            # those are just discarded
+            num_sub_domain_from_mesh = int(f.readline())
+            np.fromfile(
+                f, count=num_sub_domain_from_mesh * 4, dtype=int, sep=" "
+            ).reshape(num_sub_domain_from_mesh, 4)
+        elif items[0] == "VertexOnGeometricVertex":
+            # those are just discarded
+            num_vertex_on_geometric_vertex = int(f.readline())
+            np.fromfile(
+                f, count=num_vertex_on_geometric_vertex * 2, dtype=int, sep=" "
+            ).reshape(num_vertex_on_geometric_vertex, 2)
+        elif items[0] == "VertexOnGeometricEdge":
+            # those are just discarded
+            num_vertex_on_geometric_edge = int(f.readline())
+            np.fromfile(
+                f, count=num_vertex_on_geometric_edge * 3, dtype=float, sep=" "
+            ).reshape(num_vertex_on_geometric_edge, 3)
+        elif items[0] == "EdgeOnGeometricEdge":
+            # those are just discarded
+            num_edge_on_geometric_edge = int(f.readline())
+            np.fromfile(
+                f, count=num_edge_on_geometric_edge * 2, dtype=int, sep=" "
+            ).reshape(num_edge_on_geometric_edge, 2)
+        elif items[0] == "Identifier" or items[0] == "Geometry":
+            f.readline()
         else:
             if items[0] != "End":
                 raise ReadError("Unknown keyword '{}'.".format(items[0]))


### PR DESCRIPTION
The medit file generated from bamg (https://www.ljll.math.upmc.fr/hecht/ftp/bamg/bamg.pdf) contains keywords (partially documented in the previous link and in https://doc.freefem.org/documentation/developers.html#meshfiledatastructure) that are not compatible with meshio for now.

A sample file can be generated from :
```
MeshVersionFormatted 2
Dimension 2
Vertices 4
-2 -2 1
2 -2 2
2 2 3
-2 2 4
Edges 4
1 2 1
2 3 1
3 4 2
4 1 2
hVertices
2 2 2 2
```
with `ffbamg -g domain_bamg_g.mesh -o domain_bamg_g.0.0.mesh` :
```
MeshVersionFormatted 0

Dimension
2

Identifier
"G=domain_bamg_g.mesh;1, Date: 21/04/02 11:24 35s"

Geometry
"domain_bamg_g.mesh"

Vertices
9
-2 -2 1
2 -2 2
2 2 3
-2 2 4
0 -2 1
2 0 1
0 2 2
-2 0 2
-2.04890948652e-09 -2.04890948652e-09 0

Edges
8
1 5 1
5 2 1
2 6 1
6 3 1
3 7 2
7 4 2
4 8 2
8 1 2

Triangles
8
9 7 8 1
7 4 8 1
8 1 5 1
2 6 5 1
9 6 7 1
5 9 8 1
5 6 9 1
3 7 6 1

SubDomainFromMesh
1
3 1 1 1

VertexOnGeometricVertex
4
 1 1
 2 2
 3 3
 4 4

VertexOnGeometricEdge
4
 5 1 0.5
 6 2 0.5
 7 3 0.5
 8 4 0.5

EdgeOnGeometricEdge
8
1 1
2 1
3 2
4 2
5 3
6 3
7 4
8 4

End
```

This pull request allow the reading of the previous file.

