### PR TITLE
Suggested prototype for MED support of reading/writing point and cell sets (opposed to tags)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dist/
 doc/_build/
 *.egg-info/
 .pytest_cache/
+.idea/

--- a/meshio/_helpers.py
+++ b/meshio/_helpers.py
@@ -42,6 +42,7 @@ def read(filename, file_format: Optional[str] = None):
     :type filenames: str
 
     :returns mesh{2,3}d: The mesh data.
+    :rtype: meshio._mesh.Mesh
     """
     if is_buffer(filename, "r"):
         if file_format is None:

--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -43,6 +43,8 @@ abaqus_to_meshio_type = {
     "S8R": "quad8",
     "S8R5": "quad8",
     "S9R5": "quad9",
+    # 4 node rigid shell element
+    "R3D4": "quad",
     # "QUAD": "quad",
     # "QUAD4": "quad",
     # "QUAD5": "quad5",

--- a/meshio/abaqus/_abaqus.py
+++ b/meshio/abaqus/_abaqus.py
@@ -85,7 +85,8 @@ abaqus_to_meshio_type = {
     "C3D10MH": "tetra10",
     # "TETRA14": "tetra14",
     #
-    # "PYRAMID": "pyramid",
+    "C3D5": "pyramid",
+    "C3D5H": "pyramid",
     "C3D6": "wedge",
     #
     # 4-node bilinear displacement and pore pressure

--- a/meshio/med/_med.py
+++ b/meshio/med/_med.py
@@ -144,12 +144,12 @@ def _cell_tag_to_set(cell_data_array, cell_tags):
             for v in tag_names:
                 res = np.where(cell_data_array == tag_id)[0]
                 if len(res) > 0:
-                    shared_sets.append((v, np.add(res, 1)))
+                    shared_sets.append((v, res))
         else:
             tag_name = tag_names[0]
             res = np.where(cell_data_array == tag_id)[0]
             if len(res) > 0:
-                cell_sets[tag_name] = np.add(res, 1)
+                cell_sets[tag_name] = res
 
     for v, s in shared_sets:
         if v in cell_sets.keys():
@@ -192,9 +192,9 @@ def _point_tags_to_sets(tags, point_tags):
     for key, val in point_tags.items():
         if len(val) > 1:
             for set_name in val:
-                shared_sets.append((set_name, np.add(np.where(tags == key), 1)[0]))
+                shared_sets.append((set_name, np.where(tags == key)[0]))
         else:
-            point_sets[val[0]] = np.add(np.where(tags == key), 1)[0]
+            point_sets[val[0]] = np.where(tags == key)[0]
 
     for set_name, s in shared_sets:
         point_sets[set_name] = np.concatenate([point_sets[set_name], s])
@@ -426,7 +426,6 @@ def _add_cell_sets(cells_group, mesh, families):
     :type mesh: meshio._mesh.Mesh
     """
     cell_id_num = -4
-    # Cell tags
 
     element = families.create_group("ELEME")
     cell_sets = mesh.cell_sets
@@ -525,7 +524,7 @@ def _set_to_tags(sets, data, tag_start_int, tags, cell_block_index=None):
             continue
 
         for n in set_data:
-            ind = int(n - 1)
+            ind = int(n)
             if tagged_data[ind] != 0:  # id is already defined in another set
                 _resolve_element_in_use_by_other_set(
                     tagged_data, ind, tags, name, is_elem


### PR DESCRIPTION
Hello, in relation to what was discussed in https://github.com/nschloe/meshio/pull/1074, here is my suggestion for how MED support for point and cell sets can be included. 

I still haven't had time to fix the actual test cases for the MED files yet though. The tests are asserting the point and cell tags, not sets so tests will fail. I hope it is OK that I created the PR even though it lacks a few final steps.

Visually the box.med and cylinder.med (and one more test MED file I created) seems to transfer all sets OK (although the cell element numbering seem to have changed during the conversion?).

I will try to find some time later this week to finalize the tests and crack the cell element numbering issue . 

Maybe if @Jesusbill have some time you could take a look and see if you can figure out a way to change the previous test format from tags to sets? And I could also need some help taking a look at the cell element numbering issue too! 

The visual comparison of `cylinder.med`

![image](https://user-images.githubusercontent.com/9642232/115157406-57dd0b80-a089-11eb-98e7-631c739b6a90.png)

Another of visual comparison of `cantilever.med`.

![image](https://user-images.githubusercontent.com/9642232/115157763-47c62b80-a08b-11eb-99a9-aa4122419caa.png)

Comparison of re-numbering of cell elements:

![image](https://user-images.githubusercontent.com/9642232/115157844-a7bcd200-a08b-11eb-8984-ee9ea747cd7e.png)


Oh, and I hope its OK that I added the workspace folder for pycharm (.idea) in the gitignore and added and :rtype: statement on the _helper.read() function. It just made it a bit simpler to navigate using my IDE. 

Anyways, let me know what you think and if you have any suggestions and/or comments.

Best Regards
Kristoffer
