### PR TITLE
Fixed reading of tecplot files if the first data is a negative or decimal number

### DIFF
--- a/meshio/tecplot/_tecplot.py
+++ b/meshio/tecplot/_tecplot.py
@@ -147,7 +147,7 @@ def read_buffer(f):
             i = f.tell()
             line = readline(f).upper()
             while True:
-                if line and not line[:2].lstrip('-.').rstrip('.').isdigit():
+                if line and not line[:2].lstrip("-.").rstrip(".").isdigit():
                     lines += [line]
                     i = f.tell()
                     line = readline(f).upper()

--- a/meshio/tecplot/_tecplot.py
+++ b/meshio/tecplot/_tecplot.py
@@ -147,7 +147,7 @@ def read_buffer(f):
             i = f.tell()
             line = readline(f).upper()
             while True:
-                if line and not line[:2].lstrip('-').rstrip('.').isdigit():
+                if line and not line[:2].lstrip('-.').rstrip('.').isdigit():
                     lines += [line]
                     i = f.tell()
                     line = readline(f).upper()

--- a/meshio/tecplot/_tecplot.py
+++ b/meshio/tecplot/_tecplot.py
@@ -147,7 +147,7 @@ def read_buffer(f):
             i = f.tell()
             line = readline(f).upper()
             while True:
-                if line and not line[0].isdigit():
+                if line and not line[:2].lstrip('-').rstrip('.').isdigit():
                     lines += [line]
                     i = f.tell()
                     line = readline(f).upper()


### PR DESCRIPTION
Fixed reading of tecplot files if the first data is a negative number. The fix is straightforward, when reading the `ZONE`, the first two chars of the header lines are read checking the cases `-0` , `0.`, `00` , `.0` (or any digit combination) instead of assuming only a positive number char