### PR TITLE
Deal with orientation nodes of nastran 1D elements

### DIFF
--- a/src/meshio/nastran/_nastran.py
+++ b/src/meshio/nastran/_nastran.py
@@ -160,12 +160,15 @@ def read_buffer(f):
             cell_ref = chunks[2].strip()
             cell_ref = int(cell_ref) if len(cell_ref) > 0 else None
 
-            if keyword == "CBAR":
-                # A CBAR line can be
+            if keyword in ["CBAR", "CBEAM", "CBUSH", "CBUSH1D", "CGAP"]:
+                # Most Nastran 1D elements contain a third node (in the form of a node id or coordinates) to specify the local coordinate system:
+                # https://docs.plm.automation.siemens.com/data_services/resources/nxnastran/10/help/en_US/tdocExt/pdf/QRG.pdf
+                # For example, a CBAR line can be
                 # ```
                 # CBAR          37               3       11.0     0.0     0.0
                 # ```
-                # No idea what the last three floats are. Just remove them.
+                # where the last three floats specify the orientation vector.
+                # This information is removed.
                 cell = chunks[3:5]
             else:
                 cell = chunks[3:]


### PR DESCRIPTION
This merge request fixes an issue that occurs when reading a .fem file containing CBUSH elements. The following assertion fails:
`  File "/home/user/workspace/meshio/src/meshio/nastran/_nastran.py", line 81, in add_cell
    assert cell_type in ["tetra", "pyramid", "wedge", "hexahedron"]`
The problem is caused by the fact that CBUSH elements contain a third node to specify the local coordinate system of the element, e.g:
`CBUSH     157002     134   25455   28002                               1`
In this case, the 1 indicates a global coordinate system that is used as local coordinate system (see the [Quick Reference Guide](https://docs.plm.automation.siemens.com/data_services/resources/nxnastran/10/help/en_US/tdocExt/pdf/QRG.pdf)).
I noticed that there is already a provision to deal with these orientation nodes for CBAR elements. This pull request simply extends this solution to the other 1D Nastran elements that contain orientation information. A link to the Quick Reference Guide was also added in the comments to explain the reason for this solution.