### PR TITLE
Nastran long support

### DIFF
--- a/src/meshio/nastran/_nastran.py
+++ b/src/meshio/nastran/_nastran.py
@@ -356,7 +356,7 @@ def _chunk_line(line):
         chunks = line.split(",")
     else:  # fixed format
         CHUNK_SIZE = 8
-        chunks = [line[i : CHUNK_SIZE + i] for i in range(0, len(line), CHUNK_SIZE)]
+        chunks = [line[i : CHUNK_SIZE + i] for i in range(0, 72, CHUNK_SIZE)]
     # everything after the 9th chunk is ignored
     return chunks[:9]
 

--- a/tests/test_nastran.py
+++ b/tests/test_nastran.py
@@ -1,3 +1,4 @@
+import io
 import pathlib
 
 import helpers
@@ -46,3 +47,18 @@ def test_reference_file(filename):
         "tetra": 5309,
     }
     assert {k: v.sum() for k, v in mesh.cells} == ref_num_cells
+
+
+def test_long_format():
+    filename = io.StringIO(
+        "BEGIN BULK\n"
+        "GRID*    43                             1.50000000000000 0.0\n"
+        "*        0.\n"
+        "ENDDATA\n"
+    )
+
+    mesh = meshio.read(filename, "nastran")
+
+    # points
+    assert len(mesh.points) == 1
+    assert np.isclose(mesh.points.sum(), 1.5)


### PR DESCRIPTION
I've added a new test with a valid Nastran grid in long format that currently fails.  The issue is that `chunks2[1:3]]` in the code below will only be length 1 since the second line in the test grid card is not long enough (not more than 16 characters long).  This leads leads to `ValueError: not enough values to unpack (expected 2, got 1)`.

```python
            chunks2 = _chunk_line(next_line)
            next_line = f.readline()
            points.append(
                [
                    _nastran_string_to_float(i + j)
                    for i, j in [chunks[5:7], chunks[7:9], chunks2[1:3]]
                ]
            )
```

The solution I've added here is to simply use 72 for the line length instead of `len(line)`, which will result in the fixed format line "chunks" always having 9 fields.  It fills the empty ones with empty strings, `''`.