### PR TITLE
Adding C3D15 / wedge15 type

### DIFF
--- a/src/meshio/abaqus/_abaqus.py
+++ b/src/meshio/abaqus/_abaqus.py
@@ -87,6 +87,7 @@ abaqus_to_meshio_type = {
     #
     # "PYRAMID": "pyramid",
     "C3D6": "wedge",
+    "C3D15": "wedge15",
     #
     # 4-node bilinear displacement and pore pressure
     "CAX4P": "quad",


### PR DESCRIPTION
It looks like that C3D15 was missing in Abaqus Format.
Is it that simple to fix or did I miss something? I checked with a few meshes and I can read them just fine.