### PR TITLE
tox environments for formatting and linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ doc/_build/
 .coverage
 .tox/
 foo.vtk
+.vscode/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-skip=test/performance.py
+extend_skip=test/performance.py

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,3 @@
 [settings]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
+profile=black
 extend_skip=test/performance.py

--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,6 @@ format:
 	blacken-docs README.md
 
 lint:
+	isort --check .
 	black --check .
 	flake8 .

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,8 @@
+# usage:
+#    tox          --> default, runs pytest
+#    tox -e fmt   --> format the code and README
+#    tox -e lint  --> check code formating and lint the code
+
 [tox]
 envlist = py3
 isolated_build = True
@@ -16,16 +21,18 @@ skip_install = True
 commands =
     isort .
     black .
+    blacken-docs README.md
 deps =
     black
     isort
+    blacken-docs
 
 [testenv:lint]
 skip_install = True
 commands =
     isort --check .
-    flake8 .
     black --check .
+    flake8 .
 deps =
     black
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,23 @@ deps =
 extras = all
 commands =
     pytest {posargs} --codeblocks
+
+[testenv:fmt]
+skip_install = True
+commands =
+    isort .
+    black .
+deps =
+    black
+    isort
+
+[testenv:lint]
+skip_install = True
+commands =
+    isort --check .
+    flake8 .
+    black --check .
+deps =
+    black
+    flake8
+    isort


### PR DESCRIPTION
The main change is adding 2 new tox environments to format and lint the code.  Now you can use `tox -e fmt` to run isort and black on the code or `tox -e lint` to run black and isort in check mode as well as flake8 (same as is done in the ci checks).

A few other changes:

1. Ignore vscode settings directory
2. Change isort to use "black" compatibility mode (requires isort >5), which will ensure any future required setting changes get automatically applied too.  Let me know if you'd rather remove this though.
3. Change isort "skip" setting to "extend_skip" so that default skipped directories, such as .tox, still get skipped
