### PR TITLE
check that there is a triangle cell

### DIFF
--- a/src/meshio/stl/_stl.py
+++ b/src/meshio/stl/_stl.py
@@ -160,9 +160,7 @@ def _read_binary(f, num_triangles):
 
 def write(filename, mesh, binary=False):
     if "triangle" not in {block.type for block in mesh.cells}:
-        raise WriteError(
-            "STL can only write triangle cells.  No triangle cells found."
-        )
+        raise WriteError("STL can only write triangle cells.  No triangle cells found.")
     if len(mesh.cells) > 1:
         invalid = {block.type for block in mesh.cells if block.type != "triangle"}
         logging.warning(

--- a/src/meshio/stl/_stl.py
+++ b/src/meshio/stl/_stl.py
@@ -8,7 +8,7 @@ import os
 import numpy as np
 
 from ..__about__ import __version__
-from .._exceptions import ReadError
+from .._exceptions import ReadError, WriteError
 from .._files import open_file
 from .._helpers import register
 from .._mesh import CellBlock, Mesh
@@ -159,6 +159,10 @@ def _read_binary(f, num_triangles):
 
 
 def write(filename, mesh, binary=False):
+    if "triangle" not in {block.type for block in mesh.cells}:
+        raise WriteError(
+            "STL can only write triangle cells.  No triangle cells found."
+        )
     if len(mesh.cells) > 1:
         invalid = {block.type for block in mesh.cells if block.type != "triangle"}
         logging.warning(


### PR DESCRIPTION
Currently the STL writer fails if there is not a triangle block in the mesh.  The `pts` ends up being empty which results in `np.cross([], [])` and an exception.  This adds a check that there is a triangle block found in the mesh, or else raises a WriteError.  An empty mesh would also raise this error --- is there a desire to check for that condition too (for all applicable readers, not just STL)?  I see the empty_mesh test is commented out in the tests.