### PR TITLE
check cell_type in ascii format too

### DIFF
--- a/src/meshio/ply/_ply.py
+++ b/src/meshio/ply/_ply.py
@@ -507,6 +507,11 @@ def write(filename, mesh, binary=True):  # noqa: C901
 
             # cells
             for cell_type, data in mesh.cells:
+                if cell_type not in legal_cell_types:
+                    warnings.warn(
+                        'cell_type "{}" is not supported by ply format - skipping'
+                    )
+                    continue
                 #                if cell_type not in cell_type_to_count.keys():
                 #                    continue
                 out = np.column_stack(


### PR DESCRIPTION
Currently for the PLY writer, a check is performed when writing a binary file to make sure the cell type is supported.  This adds that same check to the ascii writer too.  As it is, I was able to write a tetrahedral mesh to PLY ascii output, which results in an invalid file.