### PR TITLE
Fix ParaView plugin crash

### DIFF
--- a/tools/paraview-meshio-plugin.py
+++ b/tools/paraview-meshio-plugin.py
@@ -12,8 +12,8 @@ from vtkmodules.vtkCommonDataModel import vtkUnstructuredGrid
 import meshio
 
 paraview_plugin_version = meshio.__version__
-vtk_to_meshio_type = meshio.vtk._vtk.vtk_to_meshio_type
-meshio_to_vtk_type = meshio.vtk._vtk.meshio_to_vtk_type
+vtk_to_meshio_type = meshio.vtk_42._vtk.vtk_to_meshio_type
+meshio_to_vtk_type = meshio.vtk_42._vtk.meshio_to_vtk_type
 meshio_input_filetypes = list(meshio._helpers.reader_map.keys())
 meshio_extensions = [ext[1:] for ext in meshio.extension_to_filetype.keys()]
 meshio_input_filetypes = ["automatic"] + meshio_input_filetypes

--- a/tools/paraview-meshio-plugin.py
+++ b/tools/paraview-meshio-plugin.py
@@ -12,8 +12,8 @@ from vtkmodules.vtkCommonDataModel import vtkUnstructuredGrid
 import meshio
 
 paraview_plugin_version = meshio.__version__
-vtk_to_meshio_type = meshio.vtk_42._vtk.vtk_to_meshio_type
-meshio_to_vtk_type = meshio.vtk_42._vtk.meshio_to_vtk_type
+vtk_to_meshio_type = meshio._vtk_common.vtk_to_meshio_type
+meshio_to_vtk_type = meshio._vtk_common.meshio_to_vtk_type
 meshio_input_filetypes = list(meshio._helpers.reader_map.keys())
 meshio_extensions = [ext[1:] for ext in meshio.extension_to_filetype.keys()]
 meshio_input_filetypes = ["automatic"] + meshio_input_filetypes


### PR DESCRIPTION
Hi all, as part of 574b88483d67044dd5afa4a7fade1c3576f4a8cf the path to the vtk module was updated from `meshio.vtk._vtk` to `meshio.vtk._vtk_42`. The ParaView plugin was not updated however, which causes it to crash directly when loaded (#1100). This PR fixes that.

Fixes #1100