### PR TITLE
Handle CHEXA (20 nodes) and CPENTA (15 nodes) nodes ordering

### DIFF
--- a/src/meshio/nastran/_nastran.py
+++ b/src/meshio/nastran/_nastran.py
@@ -270,12 +270,7 @@ def write(filename, mesh, point_format="fixed-large", cell_format="fixed-small")
         cell_id = 0
         cell_refs = mesh.cell_data.get("nastran:ref", None)
         for ict, (cell_type, cells) in enumerate(mesh.cells):
-            # Second order elements
-            if cell_type in ["hexahedron20", "wedge15"]:
-                nastran_type = meshio_to_nastran_type[cell_type]
-            # Remove '_' for first order elements
-            else:
-                nastran_type = meshio_to_nastran_type[cell_type].replace("_", "")
+            nastran_type = meshio_to_nastran_type[cell_type]
             if cell_format.endswith("-large"):
                 nastran_type += "*"
             if cell_refs is not None:


### PR DESCRIPTION
Cf discussion https://github.com/nschloe/meshio/discussions/1202

Nodes ordering for hexahedron20 and wedges15 are different between vtk and nastran. The problem has been fixed in `_convert_to_vtk_ordering` function