### PR TITLE
Depend on minimum numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
   "importlib_metadata; python_version<'3.8'",
-  "numpy"
+  "numpy>=1.20.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
meshio uses `numpy.typing` which was introduced in numpy 1.20.0 (https://numpy.org/doc/stable/release/1.20.0-notes.html#numpy-is-now-typed).

Specifying the minimum required version helps pip upgrade numpy if the environment has an older version installed.
It also lets pip catch conflicts when trying to install a big set of requirements with conflicting dependencies (numpy < 1.20.0 and meshio)