### PR TITLE
Add "wedge15" to topological_dimension dictionary

### DIFF
--- a/src/meshio/_mesh.py
+++ b/src/meshio/_mesh.py
@@ -26,6 +26,7 @@ topological_dimension = {
     "vertex": 0,
     "quad8": 2,
     "hexahedron20": 3,
+    "wedge15": 3,
     "triangle10": 2,
     "triangle15": 2,
     "triangle21": 2,


### PR DESCRIPTION
The topological_dimension dictionary in version 5.2.2 is missing information from the cell type "wedge15". This pull request is intended to fix #1247.