### PR TITLE
Fix crash when reading gmsh22 files with multiple cells

### DIFF
--- a/src/meshio/_common.py
+++ b/src/meshio/_common.py
@@ -86,7 +86,7 @@ num_nodes_per_cell = {
 
 
 def cell_data_from_raw(cells, cell_data_raw):
-    cs = np.cumsum([len(c) for c in cells])[:-1]
+    cs = np.cumsum([len(c[1]) for c in cells])[:-1]
     return {name: np.split(d, cs) for name, d in cell_data_raw.items()}
 
 

--- a/src/meshio/_common.py
+++ b/src/meshio/_common.py
@@ -86,7 +86,7 @@ num_nodes_per_cell = {
 
 
 def cell_data_from_raw(cells, cell_data_raw):
-    cs = np.cumsum([len(c[1]) for c in cells])[:-1]
+    cs = np.cumsum([len(c) for c in cells])[:-1]
     return {name: np.split(d, cs) for name, d in cell_data_raw.items()}
 
 

--- a/src/meshio/gmsh/_gmsh22.py
+++ b/src/meshio/gmsh/_gmsh22.py
@@ -68,6 +68,8 @@ def read_buffer(f, is_ascii, data_size):
         else:
             _fast_forward_to_end_block(f, environ)
 
+    cells = [CellBlock(*cell) for cell in cells]
+
     if has_additional_tag_data:
         warn("The file contains tag data that couldn't be processed.")
 
@@ -78,13 +80,14 @@ def read_buffer(f, is_ascii, data_size):
         if tag_name not in cell_data:
             cell_data[tag_name] = []
         offset = {}
-        for cell_type, cell_array in cells:
-            start = offset.setdefault(cell_type, 0)
-            end = start + len(cell_array)
-            offset[cell_type] = end
-            tags = tag_dict.get(cell_type, [])
+        for cell in cells:
+            start = offset.setdefault(cell.type, 0)
+            end = start + len(cell.data)
+            offset[cell.type] = end
+            tags = tag_dict.get(cell.type, [])
             tags = np.array(tags[start:end], dtype=c_int)
             cell_data[tag_name].append(tags)
+
 
     return Mesh(
         points,

--- a/src/meshio/gmsh/_gmsh22.py
+++ b/src/meshio/gmsh/_gmsh22.py
@@ -88,7 +88,6 @@ def read_buffer(f, is_ascii, data_size):
             tags = np.array(tags[start:end], dtype=c_int)
             cell_data[tag_name].append(tags)
 
-
     return Mesh(
         points,
         cells,

--- a/tests/test_gmsh.py
+++ b/tests/test_gmsh.py
@@ -45,6 +45,9 @@ def gmsh_periodic():
         helpers.add_field_data(helpers.tet_mesh, [1, 3], int),
         helpers.add_field_data(helpers.hex_mesh, [1, 3], int),
         gmsh_periodic(),
+        helpers.add_cell_data(helpers.line_tri_mesh, [("a", (), np.float64)]),
+        helpers.add_cell_data(helpers.line_tri_mesh, [("a", (3,), np.float64)]),
+        helpers.add_cell_data(helpers.line_tri_mesh, [("a", (9,), np.float64)]),
     ],
 )
 @pytest.mark.parametrize("binary", [False, True])


### PR DESCRIPTION
The gmsh22 reader reads cells as tuples , instead of `CellBlock`. This causes issues in determining where to split the data in `cell_data_from_raw()`. This applies when the number of cells > 1 and cell data is defined. This situation currently does not have a test in the test suite and therefore goes undetected.

This PR fixes the problem and adds tests for this case.

Closes #1257 