### PR TITLE
fix line 340 in su2

### DIFF
--- a/src/meshio/su2/_su2.py
+++ b/src/meshio/su2/_su2.py
@@ -337,7 +337,9 @@ def write(filename, mesh):
             f.write(f"MARKER_TAG= {tag}\n".encode())
             f.write(f"MARKER_ELEMS= {count}\n".encode())
 
-            for index, (cell_type, data) in enumerate(mesh.cells):
+            for index, cell_block in enumerate(mesh.cells):
+                cell_type = cell_block.type
+                data = cell_block.data
 
                 if cell_type not in types:
                     continue


### PR DESCRIPTION
In line 340 of __su.py, mesh.cells is a list containing 2 CellBlock objects and code is trying to unzip the CellBlock which is unzippable. When I'm trying to export su2 mesh files this problem raised a bug. After fixing it to this, the export works.