### PR TITLE
Fixes for exodus_to_meshio_type

### DIFF
--- a/src/meshio/exodus/_exodus.py
+++ b/src/meshio/exodus/_exodus.py
@@ -53,8 +53,8 @@ exodus_to_meshio_type = {
     "HEX27": "hexahedron27",
     #
     "TETRA": "tetra",
-    "TETRA4": "tetra4",
-    "TET4": "tetra4",
+    "TETRA4": "tetra",
+    "TET4": "tetra",
     "TETRA8": "tetra8",
     "TETRA10": "tetra10",
     "TETRA14": "tetra14",


### PR DESCRIPTION
Following changes affect the exodus_to_meshio_type dictionary:

- added exodus type "PYRAMID5", which is synonymous to "PYRAMID"
- changed meshio type "tetra4" to "tetra"

Since the meshio type "tetra4" was not recognized, a fix in the abaqus_to_meshio_type dict for "C3D4H" may also be necessary.