### PR TITLE
Add pyramid13 to topological_dimension

### DIFF
--- a/src/meshio/_mesh.py
+++ b/src/meshio/_mesh.py
@@ -22,6 +22,7 @@ topological_dimension = {
     "tetra10": 3,
     "hexahedron27": 3,
     "wedge18": 3,
+    "pyramid13": 3,
     "pyramid14": 3,
     "vertex": 0,
     "quad8": 2,


### PR DESCRIPTION
meshio raises `KeyError: 'pyramid13'` exception when reading a MED file that contains pyramid13 cell type. 

```
meshio convert tetra_pyramid.med tetra_pyramid.vtk

Traceback (most recent call last):
  File "\Anaconda3\envs\ml\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "\Anaconda3\envs\ml\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "\Anaconda3\envs\ml\Scripts\meshio.exe\__main__.py", line 7, in <module>
  File "\maema\Anaconda3\envs\ml\lib\site-packages\meshio\_cli\_main.py", line 52, in main
    return args.func(args)
  File "\Anaconda3\envs\ml\lib\site-packages\meshio\_cli\_convert.py", line 53, in convert
    mesh = read(args.infile, file_format=args.input_format)
  File "\Anaconda3\envs\ml\lib\site-packages\meshio\_helpers.py", line 71, in read
    return _read_file(Path(filename), file_format)
  File "\Anaconda3\envs\ml\lib\site-packages\meshio\_helpers.py", line 103, in _read_file
    return reader_map[file_format](str(path))
  File "\Anaconda3\envs\ml\lib\site-packages\meshio\med\_med.py", line 114, in read
    mesh = Mesh(
  File "\Anaconda3\envs\ml\lib\site-packages\meshio\_mesh.py", line 146, in __init__
    cell_block = CellBlock(
  File "\Anaconda3\envs\ml\lib\site-packages\meshio\_mesh.py", line 99, in __init__
    self.dim = topological_dimension[cell_type]
KeyError: 'pyramid13'
```

Adding `pyramid13` to `topological_dimension` seems to solve it.

