### PR TITLE
Add wedge12 to num_nodes_per_cell

### DIFF
--- a/src/meshio/_common.py
+++ b/src/meshio/_common.py
@@ -25,6 +25,7 @@ num_nodes_per_cell = {
     "quad9": 9,
     "tetra10": 10,
     "hexahedron27": 27,
+    "wedge12": 12,
     "wedge15": 15,
     "wedge18": 18,
     "pyramid13": 13,


### PR DESCRIPTION
Calling `.get_cells_type('wedge12')` fails with a `KeyError` exception because `wedge12` isn't in `_common.num_nodes_per_cell`.