### PR TITLE
Writing VTK and VTU in memory files

### DIFF
--- a/src/meshio/_cxml/etree.py
+++ b/src/meshio/_cxml/etree.py
@@ -5,6 +5,7 @@
 # written in the text fields. Converting this to ASCII first requires a lot of memory.
 # This etree here allows the writing method to write to the file directly, without
 # having to create a string representation first.
+from .._files import open_file
 
 
 class Element:
@@ -54,7 +55,7 @@ class ElementTree:
         self.root = root
 
     def write(self, filename, xml_declaration=True):
-        with open(filename, "w") as f:
+        with open_file(filename, "w") as f:
             if xml_declaration:
                 f.write('<?xml version="1.0"?>\n')
             self.root.write(f)

--- a/src/meshio/vtk/_common.py
+++ b/src/meshio/vtk/_common.py
@@ -1,0 +1,19 @@
+from io import BytesIO, StringIO
+
+
+def encode(string, binary):
+    return string.encode() if binary else string
+
+
+def tofile(arr, f, binary=True, sep=""):
+    if binary:
+        if isinstance(f, BytesIO):
+            f.write(arr.tobytes())
+        else:
+            arr.tofile(f, sep=sep)
+
+    else:
+        if isinstance(f, StringIO):
+            f.write(" ".join(str(x) for x in arr.ravel()))
+        else:
+            arr.tofile(f, sep=sep)

--- a/src/meshio/vtk/_vtk_42.py
+++ b/src/meshio/vtk/_vtk_42.py
@@ -658,9 +658,10 @@ def write(filename, mesh, binary=True):
 
 def _write_points(f, points, binary):
     f.write(
-        encode("POINTS {} {}\n".format(
-            len(points), numpy_to_vtk_dtype[points.dtype.name]
-        ), binary)
+        encode(
+            "POINTS {} {}\n".format(len(points), numpy_to_vtk_dtype[points.dtype.name]),
+            binary,
+        )
     )
 
     if binary:
@@ -716,9 +717,7 @@ def _write_cells(f, cells, binary):
 
             # prepend a column with the value n
             tofile(
-                np.column_stack(
-                    [np.full(c.data.shape[0], n, dtype=c.data.dtype), d]
-                ),
+                np.column_stack([np.full(c.data.shape[0], n, dtype=c.data.dtype), d]),
                 f,
                 binary,
                 sep="\n",

--- a/src/meshio/vtu/_vtu.py
+++ b/src/meshio/vtu/_vtu.py
@@ -13,6 +13,7 @@ import numpy as np
 from ..__about__ import __version__
 from .._common import info, join_strings, raw_from_cell_data, replace_space, warn
 from .._exceptions import CorruptionError, ReadError
+from .._files import open_file
 from .._helpers import register_format
 from .._mesh import CellBlock, Mesh
 from .._vtk_common import meshio_to_vtk_order, meshio_to_vtk_type, vtk_cells_from_data
@@ -186,7 +187,7 @@ def get_grid(root):
 def _parse_raw_binary(filename):
     from xml.etree import ElementTree as ET
 
-    with open(filename, "rb") as f:
+    with open_file(filename, "rb") as f:
         raw = f.read()
 
     try:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -652,14 +652,33 @@ def add_cell_sets(mesh):
     return mesh2
 
 
-def write_read(tmp_path, writer, reader, input_mesh, atol, extension=".dat", memory_file_is_binary=False, test_memory_file=False):
+def write_read(
+    tmp_path,
+    writer,
+    reader,
+    input_mesh,
+    atol,
+    extension=".dat",
+    memory_file_is_binary=False,
+    test_memory_file=False,
+):
     """Write and read a file, and make sure the data is the same as before."""
     _write_read(tmp_path, writer, reader, input_mesh, atol, extension)
     if test_memory_file:
-        _write_read(tmp_path, writer, reader, input_mesh, atol, extension, memory_file_type="binary" if memory_file_is_binary else "ascii")
+        _write_read(
+            tmp_path,
+            writer,
+            reader,
+            input_mesh,
+            atol,
+            extension,
+            memory_file_type="binary" if memory_file_is_binary else "ascii",
+        )
 
 
-def _write_read(tmp_path, writer, reader, input_mesh, atol, extension, memory_file_type=None):
+def _write_read(
+    tmp_path, writer, reader, input_mesh, atol, extension, memory_file_type=None
+):
     in_mesh = copy.deepcopy(input_mesh)
 
     p = tmp_path / ("test" + extension)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import string
+from io import BytesIO, StringIO
 
 import numpy as np
 
@@ -651,13 +652,36 @@ def add_cell_sets(mesh):
     return mesh2
 
 
-def write_read(tmp_path, writer, reader, input_mesh, atol, extension=".dat"):
+def write_read(tmp_path, writer, reader, input_mesh, atol, extension=".dat", memory_file_is_binary=False, test_memory_file=False):
     """Write and read a file, and make sure the data is the same as before."""
+    _write_read(tmp_path, writer, reader, input_mesh, atol, extension)
+    if test_memory_file:
+        _write_read(tmp_path, writer, reader, input_mesh, atol, extension, memory_file_type="binary" if memory_file_is_binary else "ascii")
+
+
+def _write_read(tmp_path, writer, reader, input_mesh, atol, extension, memory_file_type=None):
     in_mesh = copy.deepcopy(input_mesh)
 
     p = tmp_path / ("test" + extension)
     print(input_mesh)
     writer(p, input_mesh)
+    if memory_file_type is None:
+        writer(p, input_mesh)
+    else:
+        if memory_file_type == "ascii":
+            mode = "w"
+            with StringIO() as f:
+                writer(f, input_mesh)
+                value = f.getvalue()
+
+        elif memory_file_type == "binary":
+            mode = "wb"
+            with BytesIO() as f:
+                writer(f, input_mesh)
+                value = f.getvalue()
+
+        with open(p, mode) as f:
+            f.write(value)
     mesh = reader(p)
 
     # Make sure the output is writeable

--- a/tests/test_abaqus.py
+++ b/tests/test_abaqus.py
@@ -24,7 +24,7 @@ from . import helpers
     ],
 )
 def test(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.abaqus.write, meshio.abaqus.read, mesh, 1.0e-15)
+    helpers.write_read(tmp_path, meshio.abaqus.write, meshio.abaqus.read, mesh, 1.0e-15, test_memory_file=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_abaqus.py
+++ b/tests/test_abaqus.py
@@ -24,7 +24,14 @@ from . import helpers
     ],
 )
 def test(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.abaqus.write, meshio.abaqus.read, mesh, 1.0e-15, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        meshio.abaqus.write,
+        meshio.abaqus.read,
+        mesh,
+        1.0e-15,
+        test_memory_file=True,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_avsucd.py
+++ b/tests/test_avsucd.py
@@ -22,4 +22,4 @@ from . import helpers
     ],
 )
 def test(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.avsucd.write, meshio.avsucd.read, mesh, 1.0e-13)
+    helpers.write_read(tmp_path, meshio.avsucd.write, meshio.avsucd.read, mesh, 1.0e-13, test_memory_file=True)

--- a/tests/test_avsucd.py
+++ b/tests/test_avsucd.py
@@ -22,4 +22,11 @@ from . import helpers
     ],
 )
 def test(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.avsucd.write, meshio.avsucd.read, mesh, 1.0e-13, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        meshio.avsucd.write,
+        meshio.avsucd.read,
+        mesh,
+        1.0e-13,
+        test_memory_file=True,
+    )

--- a/tests/test_flac3d.py
+++ b/tests/test_flac3d.py
@@ -27,6 +27,8 @@ def test(mesh, binary, tmp_path):
         meshio.flac3d.read,
         mesh,
         1.0e-15,
+        memory_file_is_binary=binary,
+        test_memory_file=True,
     )
 
 

--- a/tests/test_mdpa.py
+++ b/tests/test_mdpa.py
@@ -31,7 +31,7 @@ from . import helpers
     ],
 )
 def test_io(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.mdpa.write, meshio.mdpa.read, mesh, 1.0e-15)
+    helpers.write_read(tmp_path, meshio.mdpa.write, meshio.mdpa.read, mesh, 1.0e-15, memory_file_is_binary=True, test_memory_file=True)
 
 
 def test_generic_io(tmp_path):

--- a/tests/test_mdpa.py
+++ b/tests/test_mdpa.py
@@ -31,7 +31,15 @@ from . import helpers
     ],
 )
 def test_io(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.mdpa.write, meshio.mdpa.read, mesh, 1.0e-15, memory_file_is_binary=True, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        meshio.mdpa.write,
+        meshio.mdpa.read,
+        mesh,
+        1.0e-15,
+        memory_file_is_binary=True,
+        test_memory_file=True,
+    )
 
 
 def test_generic_io(tmp_path):

--- a/tests/test_medit.py
+++ b/tests/test_medit.py
@@ -23,7 +23,15 @@ from . import helpers
     ],
 )
 def test_io(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.medit.write, meshio.medit.read, mesh, 1.0e-15, memory_file_is_binary=True, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        meshio.medit.write,
+        meshio.medit.read,
+        mesh,
+        1.0e-15,
+        memory_file_is_binary=True,
+        test_memory_file=True,
+    )
 
 
 def test_generic_io(tmp_path):

--- a/tests/test_medit.py
+++ b/tests/test_medit.py
@@ -23,7 +23,7 @@ from . import helpers
     ],
 )
 def test_io(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.medit.write, meshio.medit.read, mesh, 1.0e-15)
+    helpers.write_read(tmp_path, meshio.medit.write, meshio.medit.read, mesh, 1.0e-15, memory_file_is_binary=True, test_memory_file=True)
 
 
 def test_generic_io(tmp_path):

--- a/tests/test_nastran.py
+++ b/tests/test_nastran.py
@@ -27,7 +27,7 @@ from . import helpers
 )
 def test(mesh, tmp_path):
     helpers.write_read(
-        tmp_path, meshio.nastran.write, meshio.nastran.read, mesh, 1.0e-13
+        tmp_path, meshio.nastran.write, meshio.nastran.read, mesh, 1.0e-13, test_memory_file=True
     )
 
 

--- a/tests/test_nastran.py
+++ b/tests/test_nastran.py
@@ -27,7 +27,12 @@ from . import helpers
 )
 def test(mesh, tmp_path):
     helpers.write_read(
-        tmp_path, meshio.nastran.write, meshio.nastran.read, mesh, 1.0e-13, test_memory_file=True
+        tmp_path,
+        meshio.nastran.write,
+        meshio.nastran.read,
+        mesh,
+        1.0e-13,
+        test_memory_file=True,
     )
 
 

--- a/tests/test_netgen.py
+++ b/tests/test_netgen.py
@@ -46,6 +46,7 @@ def test(mesh, suffix, tmp_path):
         mesh,
         1.0e-13,
         extension=suffix,
+        test_memory_file=not suffix.endswith("gz"),
     )
 
 

--- a/tests/test_neuroglancer.py
+++ b/tests/test_neuroglancer.py
@@ -20,7 +20,7 @@ def test_neuroglancer(mesh, tmp_path):
         return meshio.neuroglancer.write(*args, **kwargs)
 
     # 32bit only
-    helpers.write_read(tmp_path, writer, meshio.neuroglancer.read, mesh, 1.0e-8)
+    helpers.write_read(tmp_path, writer, meshio.neuroglancer.read, mesh, 1.0e-8, memory_file_is_binary=True, test_memory_file=True)
 
 
 @pytest.mark.parametrize("filename, ref_sum, ref_num_cells", [("simple1", 20, 4)])

--- a/tests/test_neuroglancer.py
+++ b/tests/test_neuroglancer.py
@@ -20,7 +20,15 @@ def test_neuroglancer(mesh, tmp_path):
         return meshio.neuroglancer.write(*args, **kwargs)
 
     # 32bit only
-    helpers.write_read(tmp_path, writer, meshio.neuroglancer.read, mesh, 1.0e-8, memory_file_is_binary=True, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        writer,
+        meshio.neuroglancer.read,
+        mesh,
+        1.0e-8,
+        memory_file_is_binary=True,
+        test_memory_file=True,
+    )
 
 
 @pytest.mark.parametrize("filename, ref_sum, ref_num_cells", [("simple1", 20, 4)])

--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -22,7 +22,7 @@ def test_obj(mesh, tmp_path):
     for k, c in enumerate(mesh.cells):
         mesh.cells[k] = meshio.CellBlock(c.type, c.data.astype(np.int32))
 
-    helpers.write_read(tmp_path, meshio.obj.write, meshio.obj.read, mesh, 1.0e-12)
+    helpers.write_read(tmp_path, meshio.obj.write, meshio.obj.read, mesh, 1.0e-12, test_memory_file=True)
 
 
 @pytest.mark.skip("Fails point data consistency check.")

--- a/tests/test_obj.py
+++ b/tests/test_obj.py
@@ -22,7 +22,14 @@ def test_obj(mesh, tmp_path):
     for k, c in enumerate(mesh.cells):
         mesh.cells[k] = meshio.CellBlock(c.type, c.data.astype(np.int32))
 
-    helpers.write_read(tmp_path, meshio.obj.write, meshio.obj.read, mesh, 1.0e-12, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        meshio.obj.write,
+        meshio.obj.read,
+        mesh,
+        1.0e-12,
+        test_memory_file=True,
+    )
 
 
 @pytest.mark.skip("Fails point data consistency check.")

--- a/tests/test_permas.py
+++ b/tests/test_permas.py
@@ -22,7 +22,14 @@ from . import helpers
     ],
 )
 def test_io(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.permas.write, meshio.permas.read, mesh, 1.0e-15, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        meshio.permas.write,
+        meshio.permas.read,
+        mesh,
+        1.0e-15,
+        test_memory_file=True,
+    )
 
 
 def test_generic_io(tmp_path):

--- a/tests/test_permas.py
+++ b/tests/test_permas.py
@@ -22,7 +22,7 @@ from . import helpers
     ],
 )
 def test_io(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.permas.write, meshio.permas.read, mesh, 1.0e-15)
+    helpers.write_read(tmp_path, meshio.permas.write, meshio.permas.read, mesh, 1.0e-15, test_memory_file=True)
 
 
 def test_generic_io(tmp_path):

--- a/tests/test_ply.py
+++ b/tests/test_ply.py
@@ -32,7 +32,15 @@ def test_ply(mesh, binary, tmp_path):
     for k, c in enumerate(mesh.cells):
         mesh.cells[k] = meshio.CellBlock(c.type, c.data.astype(np.int32))
 
-    helpers.write_read(tmp_path, writer, meshio.ply.read, mesh, 1.0e-12, memory_file_is_binary=True, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        writer,
+        meshio.ply.read,
+        mesh,
+        1.0e-12,
+        memory_file_is_binary=True,
+        test_memory_file=True,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ply.py
+++ b/tests/test_ply.py
@@ -32,7 +32,7 @@ def test_ply(mesh, binary, tmp_path):
     for k, c in enumerate(mesh.cells):
         mesh.cells[k] = meshio.CellBlock(c.type, c.data.astype(np.int32))
 
-    helpers.write_read(tmp_path, writer, meshio.ply.read, mesh, 1.0e-12)
+    helpers.write_read(tmp_path, writer, meshio.ply.read, mesh, 1.0e-12, memory_file_is_binary=True, test_memory_file=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_su2.py
+++ b/tests/test_su2.py
@@ -18,7 +18,7 @@ this_dir = pathlib.Path(__file__).resolve().parent
 
 @pytest.mark.parametrize("mesh", test_set)
 def test(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.su2.write, meshio.su2.read, mesh, 1.0e-15)
+    helpers.write_read(tmp_path, meshio.su2.write, meshio.su2.read, mesh, 1.0e-15, memory_file_is_binary=True, test_memory_file=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_su2.py
+++ b/tests/test_su2.py
@@ -18,7 +18,15 @@ this_dir = pathlib.Path(__file__).resolve().parent
 
 @pytest.mark.parametrize("mesh", test_set)
 def test(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.su2.write, meshio.su2.read, mesh, 1.0e-15, memory_file_is_binary=True, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        meshio.su2.write,
+        meshio.su2.read,
+        mesh,
+        1.0e-15,
+        memory_file_is_binary=True,
+        test_memory_file=True,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tecplot.py
+++ b/tests/test_tecplot.py
@@ -23,7 +23,12 @@ from . import helpers
 )
 def test(mesh, tmp_path):
     helpers.write_read(
-        tmp_path, meshio.tecplot.write, meshio.tecplot.read, mesh, 1.0e-15, test_memory_file=True
+        tmp_path,
+        meshio.tecplot.write,
+        meshio.tecplot.read,
+        mesh,
+        1.0e-15,
+        test_memory_file=True,
     )
 
 

--- a/tests/test_tecplot.py
+++ b/tests/test_tecplot.py
@@ -23,7 +23,7 @@ from . import helpers
 )
 def test(mesh, tmp_path):
     helpers.write_read(
-        tmp_path, meshio.tecplot.write, meshio.tecplot.read, mesh, 1.0e-15
+        tmp_path, meshio.tecplot.write, meshio.tecplot.read, mesh, 1.0e-15, test_memory_file=True
     )
 
 

--- a/tests/test_vtk.py
+++ b/tests/test_vtk.py
@@ -44,7 +44,15 @@ def test(mesh, binary, tmp_path):
     def writer(*args, **kwargs):
         return meshio.vtk.write(*args, binary=binary, **kwargs)
 
-    helpers.write_read(tmp_path, writer, meshio.vtk.read, mesh, 1.0e-15, memory_file_is_binary=binary, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        writer,
+        meshio.vtk.read,
+        mesh,
+        1.0e-15,
+        memory_file_is_binary=binary,
+        test_memory_file=True,
+    )
 
 
 @pytest.mark.parametrize("mesh", test_set)
@@ -53,7 +61,15 @@ def test_vtk42(mesh, binary, tmp_path):
     def writer(*args, **kwargs):
         return meshio.vtk.write(*args, binary=binary, fmt_version="4.2", **kwargs)
 
-    helpers.write_read(tmp_path, writer, meshio.vtk.read, mesh, 1.0e-15, memory_file_is_binary=binary, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        writer,
+        meshio.vtk.read,
+        mesh,
+        1.0e-15,
+        memory_file_is_binary=binary,
+        test_memory_file=True,
+    )
 
 
 def test_generic_io(tmp_path):
@@ -77,7 +93,15 @@ def test_reference_file(filename, ref_sum, ref_num_cells, binary, tmp_path):
     assert mesh.cells[0].type == "triangle"
     assert len(mesh.cells[0].data) == ref_num_cells
     writer = partial(meshio.vtk.write, binary=binary)
-    helpers.write_read(tmp_path, writer, meshio.vtk.read, mesh, 1.0e-15, memory_file_is_binary=binary, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        writer,
+        meshio.vtk.read,
+        mesh,
+        1.0e-15,
+        memory_file_is_binary=binary,
+        test_memory_file=True,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_vtk.py
+++ b/tests/test_vtk.py
@@ -44,7 +44,7 @@ def test(mesh, binary, tmp_path):
     def writer(*args, **kwargs):
         return meshio.vtk.write(*args, binary=binary, **kwargs)
 
-    helpers.write_read(tmp_path, writer, meshio.vtk.read, mesh, 1.0e-15)
+    helpers.write_read(tmp_path, writer, meshio.vtk.read, mesh, 1.0e-15, memory_file_is_binary=binary, test_memory_file=True)
 
 
 @pytest.mark.parametrize("mesh", test_set)
@@ -53,7 +53,7 @@ def test_vtk42(mesh, binary, tmp_path):
     def writer(*args, **kwargs):
         return meshio.vtk.write(*args, binary=binary, fmt_version="4.2", **kwargs)
 
-    helpers.write_read(tmp_path, writer, meshio.vtk.read, mesh, 1.0e-15)
+    helpers.write_read(tmp_path, writer, meshio.vtk.read, mesh, 1.0e-15, memory_file_is_binary=binary, test_memory_file=True)
 
 
 def test_generic_io(tmp_path):
@@ -77,7 +77,7 @@ def test_reference_file(filename, ref_sum, ref_num_cells, binary, tmp_path):
     assert mesh.cells[0].type == "triangle"
     assert len(mesh.cells[0].data) == ref_num_cells
     writer = partial(meshio.vtk.write, binary=binary)
-    helpers.write_read(tmp_path, writer, meshio.vtk.read, mesh, 1.0e-15)
+    helpers.write_read(tmp_path, writer, meshio.vtk.read, mesh, 1.0e-15, memory_file_is_binary=binary, test_memory_file=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_vtu.py
+++ b/tests/test_vtu.py
@@ -52,7 +52,7 @@ def test(mesh, data_type, tmp_path):
     # ASCII files are only meant for debugging, VTK stores only 11 digits
     # <https://gitlab.kitware.com/vtk/vtk/-/issues/17038#note_264052>
     tol = 1.0e-15 if binary else 1.0e-10
-    helpers.write_read(tmp_path, writer, meshio.vtu.read, mesh, tol)
+    helpers.write_read(tmp_path, writer, meshio.vtu.read, mesh, tol, test_memory_file=True)
 
 
 def test_generic_io(tmp_path):

--- a/tests/test_vtu.py
+++ b/tests/test_vtu.py
@@ -52,7 +52,9 @@ def test(mesh, data_type, tmp_path):
     # ASCII files are only meant for debugging, VTK stores only 11 digits
     # <https://gitlab.kitware.com/vtk/vtk/-/issues/17038#note_264052>
     tol = 1.0e-15 if binary else 1.0e-10
-    helpers.write_read(tmp_path, writer, meshio.vtu.read, mesh, tol, test_memory_file=True)
+    helpers.write_read(
+        tmp_path, writer, meshio.vtu.read, mesh, tol, test_memory_file=True
+    )
 
 
 def test_generic_io(tmp_path):

--- a/tests/test_wkt.py
+++ b/tests/test_wkt.py
@@ -18,7 +18,7 @@ from . import helpers
     ],
 )
 def test_wkt(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.wkt.write, meshio.wkt.read, mesh, 1.0e-12)
+    helpers.write_read(tmp_path, meshio.wkt.write, meshio.wkt.read, mesh, 1.0e-12, test_memory_file=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_wkt.py
+++ b/tests/test_wkt.py
@@ -18,7 +18,14 @@ from . import helpers
     ],
 )
 def test_wkt(mesh, tmp_path):
-    helpers.write_read(tmp_path, meshio.wkt.write, meshio.wkt.read, mesh, 1.0e-12, test_memory_file=True)
+    helpers.write_read(
+        tmp_path,
+        meshio.wkt.write,
+        meshio.wkt.read,
+        mesh,
+        1.0e-12,
+        test_memory_file=True,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Memory files are files that are not on disk and can be manipulated as standard disk files. In my case, I need to manipulate memory files when I develop web applications.

Currently, `meshio`'s VTK and VTU writers cannot write a mesh in a memory file, e.g., the following code will raise an error:

```python
import io
import meshio

mesh = meshio.Mesh(
    [
        [0.0, 0.0, 0.0],
        [1.0, 0.0, 0.0],
        [1.0, 1.0, 0.0],
        [0.0, 1.0, 0.0],
        [0.0, 0.0, 1.0],
        [1.0, 0.0, 1.0],
        [1.0, 1.0, 1.0],
        [0.0, 1.0, 1.0],
    ],
    [("hexahedron", [[0, 1, 2, 3, 4, 5, 6, 7]])],
)

with io.BytesIO() as f:
    mesh.write(f, file_format="vtk", binary=True)
    content = f.getvalue()

```

Error: `io.UnsupportedOperation: fileno`

This pull request intends to fix this limitation. Additional tests have been added for formats that *natively* support this feature.