### PR TITLE
Save all vertex values in obj files

### DIFF
--- a/src/meshio/obj/_obj.py
+++ b/src/meshio/obj/_obj.py
@@ -111,8 +111,11 @@ def write(filename, mesh):
                 __version__, datetime.datetime.now().isoformat()
             )
         )
-        for p in mesh.points:
-            f.write(f"v {p[0]} {p[1]} {p[2]}\n")
+
+        dat = mesh.points
+        fmt = "v " + " ".join(["{}"] * dat.shape[1]) + "\n"
+        for v in dat:
+            f.write(fmt.format(*v))
 
         if "obj:vn" in mesh.point_data:
             dat = mesh.point_data["obj:vn"]


### PR DESCRIPTION
According to the Wikipedia [documentation](https://en.wikipedia.org/wiki/Wavefront_.obj_file#Geometric_vertex) of .obj files, vertex data can contain either 3 values (x, y, z), 4 values (x, y, z, w) or 6 values (x, y, z, r, g, b).
meshio can read obj files with these values, but when writing, meshio only writes the 3 first values for each point, potentially stripping away important information.
This fix will write all values of vertices, using similar code for `mesh.points` as what is used to save the other parts of the file.