### PR TITLE
Fix uchar numpy dtype

### DIFF
--- a/src/meshio/ply/_ply.py
+++ b/src/meshio/ply/_ply.py
@@ -263,7 +263,7 @@ def _read_binary(
     cell_data_dtypes,
 ):
     ply_to_numpy_dtype_string = {
-        "uchar": "i1",
+        "uchar": "u1",
         "uint": "u4",
         "uint8": "u1",
         "uint16": "u2",


### PR DESCRIPTION
I have a PLY file with headers:
```
property uchar red
property uchar green
property uchar blue
```
But when I read the PLY file with meshio I get negative RGB values:
```
{'red': array([  -1, -123,  -47, ...,  123,  -10,  -37], dtype=int8),
 'green': array([-39,  -1,  -1, ...,  -1,  -1,  -1], dtype=int8),
 'blue': array([0, 0, 0, ..., 0, 0, 0], dtype=int8)}
```
This is due to the dtype of uchar (unsigned char) being i1 (signed char) instead of u1.