### PR TITLE
Synchronize `setup.cfg` and `pyproject.toml`, bump project versions in both, and add 2-line setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meshio"
-version = "5.3.4"
+version = "7.0.1"
 description = "I/O for many mesh formats"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meshio"
-version = "5.0.0"
+version = "5.3.4"
 description = "I/O for many mesh formats"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -11,8 +11,6 @@ authors = [
   {name = "Nico Schlömer"}
 ]
 classifiers = [
-  "Development Status :: 4 - Beta",
-  "Programming Language :: Python",
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
@@ -22,12 +20,14 @@ classifiers = [
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
   "Topic :: Scientific/Engineering",
   "Topic :: Utilities"
 ]
 dependencies = [
   "importlib_metadata; python_version<'3.8'",
-  "numpy>=1.20.0"
+  "numpy>=1.20.0",
+  "rich"
 ]
 
 [project.optional-dependencies]
@@ -51,3 +51,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.isort]
 profile = "black"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = meshio
-version = 5.3.4
+version = 7.0.1
 author = Nico Schlömer et al.
 author_email = nico.schloemer@gmail.com
 description = I/O for many mesh formats

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ package_dir =
 packages = find:
 install_requires =
     importlib_metadata;python_version<"3.8"
-    numpy
+    numpy >= 1.20.0
     rich
 python_requires = >=3.7
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
# Summary

This pull request does three things:

- Attempts to synchronize `setup.cfg` and `pyproject.toml` settings so that installing from source via `build` doesn't yield an installation with a stale version like `5.0.0`.
- Bumps the project versions listed in `setup.cfg` and `pyproject.toml` from `5.3.4` and `5.0.0`, respectively, to `7.0.1`, reflecting a patch version increase above the most recent tag and release on GitHub.
- Adds a 2-line, *pro forma* `setup.py` script.

# Rationale

The current project metadata in both `setup.cfg` and `pyproject.toml` looks stale, and the data in each is in conflict. Synchronizing them would make dependency data and other metadata clearer to contributors and packagers.

The 2-line `setup.py` script is intended to ease repackaging of the project. I work at an HPC site and have to convert mesh data amongst multiple formats. This package makes my life much easier, and I am grateful for all the work that has gone into it. In order to use it on some on-site projects, I need to repackage the project from source, ideally both as a wheel and as a source distribution, for security auditing and approval. Part of the rationale for source repackaging is to enable portable installation on air-gapped systems. Given the sometimes ancient software toolchains used at HPC sites, it is much easier to repackage software with `setuptools` than it is to use `build`. To wit, I spent several hours today repackaging `flit_core`, `flit`, `pep517`, and `build` to submit for approval and auditing as a fallback plan in case this pull request adding `setup.py` is rejected. While I wholeheartedly agree that getting rid of `setup.py` is a good thing, adding the two-line version is a pragmatic alternative, particularly because it is easier to get approval where I work for code incorporated into an upstream project than it is to carry around a bespoke patch.

# Alternatives

- Regarding `setup.py`, if the goal is to avoid adding it to the project now and in the future, a simple expedient would be to document that policy in `CONTRIBUTING.md`. If that is indeed project policy, I am happy to add such text to that file. I saw the discussion in #1223 and #1224 also, but I suspect other potential contributors may not see this discussion.
- I saw a [`meshio-rewrite` project](https://pypi.org/project/meshio-rewrite/) on PyPI, but the homepage listed at https://github.com/meshpro/meshio is inaccessible, and it's not entirely clear to me what the relationship of that project is to this one. If the version of the rewrite is indeed 7.0.6, then perhaps these contributions need to be added to that repo instead, or maybe the version number used in this pull request should be different from version 7.0.1.
- It seems that `build` and `flit` both use `pyproject.toml` data by default. If the goal is to move away from `setuptools`, it may be worth getting rid of `setup.cfg` altogether in favor of `pyproject.toml`, though it's not clear to me how the ParaView meshio plugin would be distributed using `pyproject.toml`, given its lack of support for `data_files`.
