### PR TITLE
fix dtype of data from vtk binary file as same as ascii file

### DIFF
--- a/src/meshio/vtk/_vtk_42.py
+++ b/src/meshio/vtk/_vtk_42.py
@@ -355,8 +355,7 @@ def _read_coords(f, data_type, is_ascii, num_points):
     else:
         # Binary data is big endian, see
         # <https://vtk.org/Wiki/VTK/Writing_VTK_files_using_python#.22legacy.22>.
-        dtype = dtype.newbyteorder(">")
-        coords = np.fromfile(f, count=num_points, dtype=dtype)
+        coords = np.fromfile(f, count=num_points, dtype=dtype.newbyteorder(">")).astype(dtype)
         line = f.readline().decode()
         if line != "\n":
             raise ReadError()
@@ -370,8 +369,7 @@ def _read_points(f, data_type, is_ascii, num_points):
     else:
         # Binary data is big endian, see
         # <https://vtk.org/Wiki/VTK/Writing_VTK_files_using_python#.22legacy.22>.
-        dtype = dtype.newbyteorder(">")
-        points = np.fromfile(f, count=num_points * 3, dtype=dtype)
+        points = np.fromfile(f, count=num_points * 3, dtype=dtype.newbyteorder(">")).astype(dtype)
         line = f.readline().decode()
         if line != "\n":
             raise ReadError()
@@ -382,8 +380,7 @@ def _read_int_data(f, is_ascii, num_items, dtype=np.dtype("int32")):
     if is_ascii:
         c = np.fromfile(f, count=num_items, sep=" ", dtype=dtype)
     else:
-        dtype = dtype.newbyteorder(">")
-        c = np.fromfile(f, count=num_items, dtype=dtype)
+        c = np.fromfile(f, count=num_items, dtype=dtype.newbyteorder(">")).astype(dtype)
         line = f.readline().decode()
         if line != "\n":
             raise ReadError()
@@ -395,7 +392,7 @@ def _read_cell_types(f, is_ascii, num_items):
         ct = np.fromfile(f, count=int(num_items), sep=" ", dtype=int)
     else:
         # binary
-        ct = np.fromfile(f, count=int(num_items), dtype=">i4")
+        ct = np.fromfile(f, count=int(num_items), dtype=">i4").astype(int)
         line = f.readline().decode()
         # Sometimes, there's no newline at the end
         if line.strip() != "":
@@ -426,8 +423,7 @@ def _read_scalar_field(f, num_data, split, is_ascii):
     else:
         # Binary data is big endian, see
         # <https://vtk.org/Wiki/VTK/Writing_VTK_files_using_python#.22legacy.22>.
-        dtype = dtype.newbyteorder(">")
-        data = np.fromfile(f, count=num_data * num_comp, dtype=dtype)
+        data = np.fromfile(f, count=num_data * num_comp, dtype=dtype.newbyteorder(">")).astype(dtype)
         line = f.readline().decode()
         if line != "\n":
             raise ReadError()
@@ -450,8 +446,7 @@ def _read_field(f, num_data, split, shape, is_ascii):
     else:
         # Binary data is big endian, see
         # <https://vtk.org/Wiki/VTK/Writing_VTK_files_using_python#.22legacy.22>.
-        dtype = dtype.newbyteorder(">")
-        data = np.fromfile(f, count=k * num_data, dtype=dtype)
+        data = np.fromfile(f, count=k * num_data, dtype=dtype.newbyteorder(">")).astype(dtype)
         line = f.readline().decode()
         if line != "\n":
             raise ReadError()
@@ -479,8 +474,7 @@ def _read_fields(f, num_fields, is_ascii):
         else:
             # Binary data is big endian, see
             # <https://vtk.org/Wiki/VTK/Writing_VTK_files_using_python#.22legacy.22>.
-            dtype = dtype.newbyteorder(">")
-            dat = np.fromfile(f, count=shape0 * shape1, dtype=dtype)
+            dat = np.fromfile(f, count=shape0 * shape1, dtype=dtype.newbyteorder(">")).astype(dtype)
             line = f.readline().decode()
             if line != "\n":
                 raise ReadError()

--- a/src/meshio/vtk/_vtk_51.py
+++ b/src/meshio/vtk/_vtk_51.py
@@ -328,8 +328,7 @@ def _read_coords(f, data_type, is_ascii, num_points):
     else:
         # Binary data is big endian, see
         # <https://vtk.org/Wiki/VTK/Writing_VTK_files_using_python#.22legacy.22>.
-        dtype = dtype.newbyteorder(">")
-        coords = np.fromfile(f, count=num_points, dtype=dtype)
+        coords = np.fromfile(f, count=num_points, dtype=dtype.newbyteorder(">")).astype(dtype)
         line = f.readline().decode()
         if line != "\n":
             raise ReadError()
@@ -343,8 +342,7 @@ def _read_points(f, data_type, is_ascii, num_points):
     else:
         # Binary data is big endian, see
         # <https://vtk.org/Wiki/VTK/Writing_VTK_files_using_python#.22legacy.22>.
-        dtype = dtype.newbyteorder(">")
-        points = np.fromfile(f, count=num_points * 3, dtype=dtype)
+        points = np.fromfile(f, count=num_points * 3, dtype=dtype.newbyteorder(">")).astype(dtype)
         line = f.readline().decode()
         if line != "\n":
             raise ReadError()
@@ -355,8 +353,7 @@ def _read_int_data(f, is_ascii, num_items, dtype):
     if is_ascii:
         c = np.fromfile(f, count=num_items, sep=" ", dtype=dtype)
     else:
-        dtype = dtype.newbyteorder(">")
-        c = np.fromfile(f, count=num_items, dtype=dtype)
+        c = np.fromfile(f, count=num_items, dtype=dtype.newbyteorder(">")).astype(dtype)
         line = f.readline().decode()
         if line != "\n":
             raise ReadError("Expected newline")
@@ -368,7 +365,7 @@ def _read_cell_types(f, is_ascii, num_items):
         ct = np.fromfile(f, count=int(num_items), sep=" ", dtype=int)
     else:
         # binary
-        ct = np.fromfile(f, count=int(num_items), dtype=">i4")
+        ct = np.fromfile(f, count=int(num_items), dtype=">i4").astype(int)
         line = f.readline().decode()
         # Sometimes, there's no newline at the end
         if line.strip() != "":
@@ -399,8 +396,7 @@ def _read_scalar_field(f, num_data, split, is_ascii):
     else:
         # Binary data is big endian, see
         # <https://vtk.org/Wiki/VTK/Writing_VTK_files_using_python#.22legacy.22>.
-        dtype = dtype.newbyteorder(">")
-        data = np.fromfile(f, count=num_data * num_comp, dtype=dtype)
+        data = np.fromfile(f, count=num_data * num_comp, dtype=dtype.newbyteorder(">")).astype(dtype)
         line = f.readline().decode()
         if line != "\n":
             raise ReadError()
@@ -423,8 +419,7 @@ def _read_field(f, num_data, split, shape, is_ascii):
     else:
         # Binary data is big endian, see
         # <https://vtk.org/Wiki/VTK/Writing_VTK_files_using_python#.22legacy.22>.
-        dtype = dtype.newbyteorder(">")
-        data = np.fromfile(f, count=k * num_data, dtype=dtype)
+        data = np.fromfile(f, count=k * num_data, dtype=dtype.newbyteorder(">")).astype(dtype)
         line = f.readline().decode()
         if line != "\n":
             raise ReadError()
@@ -452,8 +447,7 @@ def _read_fields(f, num_fields, is_ascii):
         else:
             # Binary data is big endian, see
             # <https://vtk.org/Wiki/VTK/Writing_VTK_files_using_python#.22legacy.22>.
-            dtype = dtype.newbyteorder(">")
-            dat = np.fromfile(f, count=shape0 * shape1, dtype=dtype)
+            dat = np.fromfile(f, count=shape0 * shape1, dtype=dtype.newbyteorder(">")).astype(dtype)
             line = f.readline().decode()
             if line != "\n":
                 raise ReadError()


### PR DESCRIPTION
When reading vtk binary file, dtype is encoded as `newbyteorder('>')` which is not handled in writing other formats like `ply` and causes error:

`meshio convert example.vtk example.ply`
~~~
Traceback (most recent call last):
  File "/opt/homebrew/bin/meshio", line 8, in <module>
    sys.exit(main())
  File "/opt/homebrew/lib/python3.9/site-packages/meshio/_cli/_main.py", line 52, in main
    return args.func(args)
  File "/opt/homebrew/lib/python3.9/site-packages/meshio/_cli/_convert.py", line 75, in convert
    write(args.outfile, mesh, **kwargs)
  File "/opt/homebrew/lib/python3.9/site-packages/meshio/_helpers.py", line 188, in write
    return writer(filename, mesh, **kwargs)
  File "/opt/homebrew/lib/python3.9/site-packages/meshio/ply/_ply.py", line 427, in write
    type_name = type_name_table[mesh.points.dtype]
KeyError: dtype('>f4')
~~~