### PR TITLE
Define topological dimension for wedge15

### DIFF
--- a/src/meshio/_mesh.py
+++ b/src/meshio/_mesh.py
@@ -21,6 +21,7 @@ topological_dimension = {
     "quad9": 2,
     "tetra10": 3,
     "hexahedron27": 3,
+    "wedge15": 3,
     "wedge18": 3,
     "pyramid14": 3,
     "vertex": 0,


### PR DESCRIPTION
Hi @nschloe long time no see :-)

I run into this element while reading an Abaqus INP file. Without this new line I got
```
E:\Programs\Miniconda3\Lib\site-packages\meshio\abaqus\_abaqus.py in read(filename)
    104     """Reads a Abaqus inp file."""
    105     with open_file(filename, "r") as f:
--> 106         out = read_buffer(f)
    107     return out
    108 
...
---> 99             self.dim = topological_dimension[cell_type]
    100 
    101         self.tags = [] if tags is None else tags

KeyError: 'wedge15'
```