### PR TITLE
[MDPA] write meshio's cells set as mdpa's submodelparts

### DIFF
--- a/src/meshio/mdpa/_mdpa.py
+++ b/src/meshio/mdpa/_mdpa.py
@@ -548,13 +548,13 @@ def write(filename, mesh, float_fmt=".16e", binary=False):
         # identify entities
         _write_nodes(fh, points, float_fmt, binary)
         _write_elements_and_conditions(fh, cells, tag_data, binary, dimension)
-        for name, dat in mesh.point_data.items():
-            _write_data(fh, "NodalData", name, dat, binary)
-        cell_data_raw = raw_from_cell_data(other_data)
-        for name, dat in cell_data_raw.items():
-            # assume always that the components are elements (for now)
-            _write_data(fh, "ElementalData", name, dat, binary)
         _write_submodelparts(fh, mesh, binary, dimension)
+        #for name, dat in mesh.point_data.items():
+        #    _write_data(fh, "NodalData", name, dat, binary)
+        #cell_data_raw = raw_from_cell_data(other_data)
+        #for name, dat in cell_data_raw.items():
+        #    # assume always that the components are elements (for now)
+        #    _write_data(fh, "ElementalData", name, dat, binary)
 
 
 register_format("mdpa", [".mdpa"], read, {"mdpa": write})

--- a/src/meshio/mdpa/_mdpa.py
+++ b/src/meshio/mdpa/_mdpa.py
@@ -399,9 +399,11 @@ def _write_elements_and_conditions(fh, cells, tag_data, binary=False, dimension=
 
         # Write block
         fh.write(f"Begin {entity} {type}\n".encode())
-        for ie, pe in enumerate(b.data):
-            fh.write(f"  {offset[entity][ib] + ie + 1} 0 ".encode())
-            fh.write(f"{pe[0]+1} {pe[1]+1} {pe[2]+1}\n".encode())
+        for ie, pe0 in enumerate(b.data):
+            line = f"  {offset[entity][ib] + ie + 1} 0 "
+            line += " ".join([str(x + 1) for x in pe0])
+            line += "\n"
+            fh.write(line.encode())
         fh.write(f"End {entity}\n\n".encode())
 
 

--- a/src/meshio/mdpa/_mdpa.py
+++ b/src/meshio/mdpa/_mdpa.py
@@ -31,6 +31,7 @@ _mdpa_to_meshio_type = {
     "Hexahedra3D8": "hexahedron",
     "Prism3D6": "wedge",
     "Line2D3": "line3",
+    "Line3D3": "line3",
     "Triangle2D6": "triangle6",
     "Triangle3D6": "triangle6",
     "Quadrilateral2D9": "quad9",
@@ -45,19 +46,19 @@ _mdpa_to_meshio_type = {
 }
 
 _meshio_to_mdpa_type = {
-    "line": "Line2D2",
-    "triangle": "Triangle2D3",
-    "quad": "Quadrilateral2D4",
+    "line": "Line3D2",
+    "triangle": "Triangle3D3",
+    "quad": "Quadrilateral3D4",
     "tetra": "Tetrahedra3D4",
     "hexahedron": "Hexahedra3D8",
     "wedge": "Prism3D6",
-    "line3": "Line2D3",
-    "triangle6": "Triangle2D6",
-    "quad9": "Quadrilateral2D9",
+    "line3": "Line3D3",
+    "triangle6": "Triangle3D6",
+    "quad9": "Quadrilateral3D9",
     "tetra10": "Tetrahedra3D10",
     "hexahedron27": "Hexahedra3D27",
-    "vertex": "Point2D",
-    "quad8": "Quadrilateral2D8",
+    "vertex": "Point3D",
+    "quad8": "Quadrilateral3D8",
     "hexahedron20": "Hexahedra3D20",
 }
 inverse_num_nodes_per_cell = {v: k for k, v in num_nodes_per_cell.items()}

--- a/tests/test_mdpa.py
+++ b/tests/test_mdpa.py
@@ -38,3 +38,413 @@ def test_generic_io(tmp_path):
     helpers.generic_io(tmp_path / "test.mesh")
     # With additional, insignificant suffix:
     helpers.generic_io(tmp_path / "test.0.mesh")
+
+
+def test_write_from_gmsh(tmp_path):
+    fg = tmp_path / "test.msh"
+    fg.write_text(msh_mesh)
+    m = meshio.read(fg, "gmsh")
+    fk = tmp_path / "test.mdpa"
+    m.write(fk, "mdpa")
+    mdpa_mesh = fk.read_text().split("\n")
+    assert mdpa_mesh == mdpa_mesh_ref
+
+
+msh_mesh = """$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+6
+2 2 "Inlet"
+2 3 "Outlet"
+2 4 "SYMM-Y0"
+2 5 "Wall"
+2 6 "SYMM-Z0"
+3 1 "Fluid"
+$EndPhysicalNames
+$Entities
+6 9 5 1
+1 0 0 0 0
+2 0 0 0.2 0
+3 0 0.2 0 0
+4 0.2 0 0 0
+5 0.2 0 0.2 0
+10 0.2 0.2 0 0
+1 0 0 0 0 0 0.2 0 2 1 -2
+2 0 0 0 0 0.2 0 0 2 3 -1
+3 0 0 1.387778780781446e-17 0 0.2 0.2 0 2 2 -3
+7 0.2 0 0 0.2 0 0.2 0 2 4 -5
+8 0.2 0 1.387778780781446e-17 0.2 0.2 0.2 0 2 5 -10
+9 0.2 0 0 0.2 0.2 0 0 2 10 -4
+11 0 0 0 0.2 0 0 0 2 1 -4
+12 0 0 0.2 0.2 0 0.2 0 2 2 -5
+16 0 0.2 0 0.2 0.2 0 0 2 3 -10
+5 0 0 0 0 0.2 0.2 1 2 3 1 3 2
+13 0 0 0 0.2 0 0.2 1 4 4 1 12 -7 -11
+17 0 0 0 0.2 0.2 0.2 1 5 4 3 16 -8 -12
+21 0 0 0 0.2 0.2 0 1 6 4 2 11 -9 -16
+22 0.2 0 0 0.2 0.2 0.2 1 3 3 7 8 9
+1 0 0 0 0.2 0.2 0.2 1 1 5 -5 22 13 17 21
+$EndEntities
+$Nodes
+18 24 1 24
+0 1 0 1
+1
+0 0 0
+0 2 0 1
+2
+0 0 0.2
+0 3 0 1
+3
+0 0.2 0
+0 4 0 1
+4
+0.2 0 0
+0 5 0 1
+5
+0.2 0 0.2
+0 10 0 1
+6
+0.2 0.2 0
+1 1 0 2
+7
+8
+0 0 0.06666666666650216
+0 0 0.1333333333331544
+1 2 0 2
+9
+10
+0 0.1333333333335178 0
+0 0.06666666666685292 0
+1 3 0 2
+11
+12
+0 0.1000000002601682 0.1732050806066796
+0 0.1732050809154458 0.09999999972536942
+1 7 0 2
+13
+14
+0.2 0 0.06666666666650216
+0.2 0 0.1333333333331544
+1 8 0 2
+15
+16
+0.2 0.1000000002601682 0.1732050806066796
+0.2 0.1732050809154458 0.09999999972536942
+1 9 0 2
+17
+18
+0.2 0.1333333333335178 0
+0.2 0.06666666666685292 0
+2 5 0 3
+19
+20
+21
+0 0.1094024180527431 0.06355262272139157
+0 0.06303928009977956 0.1102111067340192
+0 0.05514522520565465 0.05557793336458285
+2 13 0 0
+2 17 0 0
+2 21 0 0
+2 22 0 3
+22
+23
+24
+0.2 0.1094024180527431 0.06355262272139157
+0.2 0.06303928009977956 0.1102111067340192
+0.2 0.05514522520565465 0.05557793336458285
+3 1 0 0
+$EndNodes
+$Elements
+9 30 1 30
+2 5 2 1
+1 20 19 21
+2 5 3 6
+2 9 19 12 3
+3 10 21 19 9
+4 20 21 7 8
+5 11 20 8 2
+6 11 12 19 20
+7 1 7 21 10
+2 13 3 3
+8 1 7 13 4
+9 7 8 14 13
+10 8 2 5 14
+2 17 3 3
+11 2 11 15 5
+12 11 12 16 15
+13 12 3 6 16
+2 21 3 3
+14 3 9 17 6
+15 9 10 18 17
+16 10 1 4 18
+2 22 2 1
+17 23 22 24
+2 22 3 6
+18 17 22 16 6
+19 18 24 22 17
+20 23 24 13 14
+21 15 23 14 5
+22 15 16 22 23
+23 4 13 24 18
+3 1 5 6
+24 12 19 9 3 16 22 17 6
+25 19 21 10 9 22 24 18 17
+26 7 21 20 8 13 24 23 14
+27 8 20 11 2 14 23 15 5
+28 19 12 11 20 22 16 15 23
+29 21 7 1 10 24 13 4 18
+3 1 6 1
+30 19 20 21 22 23 24
+$EndElements
+"""
+
+mdpa_mesh_ref = """Begin ModelPartData
+End ModelPartData
+
+Begin Properties 0
+End Properties
+
+Begin Nodes
+ 1 0.0000000000000000e+00 0.0000000000000000e+00 0.0000000000000000e+00
+ 2 0.0000000000000000e+00 0.0000000000000000e+00 2.0000000000000001e-01
+ 3 0.0000000000000000e+00 2.0000000000000001e-01 0.0000000000000000e+00
+ 4 2.0000000000000001e-01 0.0000000000000000e+00 0.0000000000000000e+00
+ 5 2.0000000000000001e-01 0.0000000000000000e+00 2.0000000000000001e-01
+ 6 2.0000000000000001e-01 2.0000000000000001e-01 0.0000000000000000e+00
+ 7 0.0000000000000000e+00 0.0000000000000000e+00 6.6666666666502158e-02
+ 8 0.0000000000000000e+00 0.0000000000000000e+00 1.3333333333315439e-01
+ 9 0.0000000000000000e+00 1.3333333333351780e-01 0.0000000000000000e+00
+ 10 0.0000000000000000e+00 6.6666666666852920e-02 0.0000000000000000e+00
+ 11 0.0000000000000000e+00 1.0000000026016820e-01 1.7320508060667961e-01
+ 12 0.0000000000000000e+00 1.7320508091544581e-01 9.9999999725369423e-02
+ 13 2.0000000000000001e-01 0.0000000000000000e+00 6.6666666666502158e-02
+ 14 2.0000000000000001e-01 0.0000000000000000e+00 1.3333333333315439e-01
+ 15 2.0000000000000001e-01 1.0000000026016820e-01 1.7320508060667961e-01
+ 16 2.0000000000000001e-01 1.7320508091544581e-01 9.9999999725369423e-02
+ 17 2.0000000000000001e-01 1.3333333333351780e-01 0.0000000000000000e+00
+ 18 2.0000000000000001e-01 6.6666666666852920e-02 0.0000000000000000e+00
+ 19 0.0000000000000000e+00 1.0940241805274310e-01 6.3552622721391575e-02
+ 20 0.0000000000000000e+00 6.3039280099779563e-02 1.1021110673401920e-01
+ 21 0.0000000000000000e+00 5.5145225205654652e-02 5.5577933364582853e-02
+ 22 2.0000000000000001e-01 1.0940241805274310e-01 6.3552622721391575e-02
+ 23 2.0000000000000001e-01 6.3039280099779563e-02 1.1021110673401920e-01
+ 24 2.0000000000000001e-01 5.5145225205654652e-02 5.5577933364582853e-02
+End Nodes
+
+Begin Conditions Triangle3D3
+  1 0 20 19 21
+End Conditions
+
+Begin Conditions Quadrilateral3D4
+  2 0 9 19 12 3
+  3 0 10 21 19 9
+  4 0 20 21 7 8
+  5 0 11 20 8 2
+  6 0 11 12 19 20
+  7 0 1 7 21 10
+End Conditions
+
+Begin Conditions Quadrilateral3D4
+  8 0 1 7 13 4
+  9 0 7 8 14 13
+  10 0 8 2 5 14
+End Conditions
+
+Begin Conditions Quadrilateral3D4
+  11 0 2 11 15 5
+  12 0 11 12 16 15
+  13 0 12 3 6 16
+End Conditions
+
+Begin Conditions Quadrilateral3D4
+  14 0 3 9 17 6
+  15 0 9 10 18 17
+  16 0 10 1 4 18
+End Conditions
+
+Begin Conditions Triangle3D3
+  17 0 23 22 24
+End Conditions
+
+Begin Conditions Quadrilateral3D4
+  18 0 17 22 16 6
+  19 0 18 24 22 17
+  20 0 23 24 13 14
+  21 0 15 23 14 5
+  22 0 15 16 22 23
+  23 0 4 13 24 18
+End Conditions
+
+Begin Elements Hexahedra3D8
+  1 0 12 19 9 3 16 22 17 6
+  2 0 19 21 10 9 22 24 18 17
+  3 0 7 21 20 8 13 24 23 14
+  4 0 8 20 11 2 14 23 15 5
+  5 0 19 12 11 20 22 16 15 23
+  6 0 21 7 1 10 24 13 4 18
+End Elements
+
+Begin Elements Prism3D6
+  7 0 19 20 21 22 23 24
+End Elements
+
+Begin SubModelPart Inlet
+    Begin SubModelPartNodes
+        1
+        2
+        3
+        7
+        8
+        9
+        10
+        11
+        12
+        19
+        20
+        21
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+        1
+        2
+        3
+        4
+        5
+        6
+        7
+    End SubModelPartConditions
+End SubModelPart
+
+Begin SubModelPart Outlet
+    Begin SubModelPartNodes
+        4
+        5
+        6
+        13
+        14
+        15
+        16
+        17
+        18
+        22
+        23
+        24
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+        17
+        18
+        19
+        20
+        21
+        22
+        23
+    End SubModelPartConditions
+End SubModelPart
+
+Begin SubModelPart SYMM-Y0
+    Begin SubModelPartNodes
+        1
+        2
+        4
+        5
+        7
+        8
+        13
+        14
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+        8
+        9
+        10
+    End SubModelPartConditions
+End SubModelPart
+
+Begin SubModelPart Wall
+    Begin SubModelPartNodes
+        2
+        3
+        5
+        6
+        11
+        12
+        15
+        16
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+        11
+        12
+        13
+    End SubModelPartConditions
+End SubModelPart
+
+Begin SubModelPart SYMM-Z0
+    Begin SubModelPartNodes
+        1
+        3
+        4
+        6
+        9
+        10
+        17
+        18
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+        14
+        15
+        16
+    End SubModelPartConditions
+End SubModelPart
+
+Begin SubModelPart Fluid
+    Begin SubModelPartNodes
+        1
+        2
+        3
+        4
+        5
+        6
+        7
+        8
+        9
+        10
+        11
+        12
+        13
+        14
+        15
+        16
+        17
+        18
+        19
+        20
+        21
+        22
+        23
+        24
+    End SubModelPartNodes
+    Begin SubModelPartElements
+        1
+        2
+        3
+        4
+        5
+        6
+        7
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+
+""".split(
+    "\n"
+)


### PR DESCRIPTION
With this PR, meshio can write cells sets (from gmsh "Physical ...", for example "Inlet", "Outlet", "Walls", "Fluid") as MDPA's submodelparts.

The main necessary change here is to discriminate between regular "Elements" and "Conditions" (i.e., elements where boundary conditions are applied, generally belonging to the skin of the model). 

I also commented out the functions to write NodalData and ElementalData, as they generate an invalid mdpa at the moment.

I added a test that compares the mdpa mesh obtained from a gmsh mesh, with a reference mdpa mesh.