### PR TITLE
:bug: (_nastran): fix converting float values into nastran string

### DIFF
--- a/src/meshio/nastran/_nastran.py
+++ b/src/meshio/nastran/_nastran.py
@@ -408,11 +408,14 @@ def _float_to_nastran_string(value, length=16):
         1234.56789 --> "1.23456789E+3"
         -0.1234 --> "-1.234E-1"
         3.1415926535897932 --> "3.14159265359E+0"
+        -0.09466145283577683 --> "-9.4661452836E-2"
     """
-    out = np.format_float_scientific(value, exp_digits=1, precision=11).replace(
-        "e", "E"
-    )
-    assert len(out) <= 16
+    precision_number = length - 5
+    out = np.format_float_scientific(
+        value, exp_digits=1, precision=precision_number).replace("e", "E")
+    if (len(out) > length):
+        out = np.format_float_scientific(
+            value, exp_digits=1, precision=precision_number - (len(out) - length)).replace("e", "E")
     return out
     # The following is the manual float conversion. Keep it around for a while in case
     # we still need it.


### PR DESCRIPTION
if a float value is negative and preicise, then the constraint
(len(out)<=len) can not be satisfied. Example: -0.09466145283577683.
fix this using dynamic precision setting.
when convert float -0.09466145283577683, the length of variable `out` is 17 > 16.
after the bug-fix, the length will be 16.