### PR TITLE
Slot and Group delimiter for flac3d conversion

### DIFF
--- a/src/meshio/flac3d/_flac3d.py
+++ b/src/meshio/flac3d/_flac3d.py
@@ -506,14 +506,21 @@ def _write_groups(f, cells, materials, flag, binary) -> None:
 
     if binary:
         f.write(struct.pack("<I", len(materials)))
-        for label, group in materials.items():
+        for label, zgroup in materials.items():
+            
+            if "=" in label:
+                slot, zgroup = label.split("=")
+            else:
+                slot = "Default"
+                zgroup = label
+
             num_chars, num_zones = len(label), len(group)
             fmt = f"<H{num_chars}sH7sI{num_zones}I"
             tmp = [
                 num_chars,
-                label.encode(),
+                zgroup.encode(),
                 7,
-                b"Default",  # slot
+                slot.encode(),  # slot
                 num_zones,
                 *group,
             ]
@@ -523,7 +530,14 @@ def _write_groups(f, cells, materials, flag, binary) -> None:
 
         f.write(f"* {flag.upper()} GROUPS\n")
         for label, group in materials.items():
-            f.write(f'{flg} "{label}" SLOT 1\n')
+
+            if "=" in label:
+                slot, zgroup = label.split("=")
+            else:
+                slot = "Default"
+                zgroup = label
+
+            f.write(f'{flg} "{zgroup}" SLOT {slot}\n')
             _write_table(f, group)
 
 


### PR DESCRIPTION
Propose change to ```_flac3d.py``` to recognise the occurrence of an equals sign "=" within a zone group label. If present, the "=" is used as a delimiter to define both the Slot name and Group name within Flac3D. This change enables zones to be assigned to multiple slots when converting a mesh from another format into Flac3D. The use of the "=" delimiter is consistent with the syntax adopted by Flac3D. A minimum working example converting a mesh created in Gmsh to Flac3D is provided for demonstration.

```python
import gmsh
import meshio

gmsh.initialize()
gmsh.model.occ.add_disk(0,0,0,0.5,0.5,1)
gmsh.model.occ.add_rectangle(-5,-5,0,10,10,2)
gmsh.model.occ.fragment([(2,2)],[(2,1)])
gmsh.model.occ.extrude([(2,1),(2,2)],0,0,1,[2])
gmsh.model.occ.synchronize()

## Inclusion of an "=" within the Gmsh Physical Group is used to 
## delimit Slot and Group names during conversion to Flac3D
gmsh.model.addPhysicalGroup(3,[1],name='SLOT_1=GROUP_1')
gmsh.model.addPhysicalGroup(3,[2],name='SLOT_2=GROUP_2')
gmsh.model.addPhysicalGroup(3,[1,2],name='SLOT_3=GROUPS_1_AND_2')

gmsh.model.mesh.generate(3)
gmsh.write("test.msh")
gmsh.finalize()

m = meshio.read('test.msh')
meshio.flac3d.write('test.f3grid',m)
```