### PR TITLE
correct `h5` path when writing time series

### DIFF
--- a/src/meshio/xdmf/time_series.py
+++ b/src/meshio/xdmf/time_series.py
@@ -262,7 +262,7 @@ class TimeSeriesWriter:
         if self.data_format == "HDF":
             import h5py
 
-            self.h5_filename = self.filename.stem + ".h5"
+            self.h5_filename = self.filename.with_suffix(".h5")
             self.h5_file = h5py.File(self.h5_filename, "w")
         return self
 


### PR DESCRIPTION
Hi Nico, 

I noticed that the path for the `.h5` file isn't correct especially when writing a time series to a file inside a sub-directory.
 
Specifically the line https://github.com/nschloe/meshio/blob/0138cc8692b806b44b32d344f7961e8370121ff7/src/meshio/xdmf/time_series.py#L265

should instead be `self.h5_filename = self.filename.with_suffix(".h5")`. 

This is consistent with what is in `main.py` https://github.com/nschloe/meshio/blob/0138cc8692b806b44b32d344f7961e8370121ff7/src/meshio/xdmf/main.py#L353

