### PR TITLE
Netgen format compatibility

### DIFF
--- a/src/meshio/netgen/_netgen.py
+++ b/src/meshio/netgen/_netgen.py
@@ -311,6 +311,8 @@ def read_buffer(f):
 
         elif line in [
             "face_colours",
+            "face_transparencies",
+            "facedescriptors",
             "singular_edge_left",
             "singular_edge_right",
             "singular_face_inside",


### PR DESCRIPTION
Skip "facedescriptor" and "face_transparencies" data blocks, which are present in new Netgen formats.