### PR TITLE
Bugfix: param "binary" not set

### DIFF
--- a/src/meshio/_cli/_convert.py
+++ b/src/meshio/_cli/_convert.py
@@ -71,5 +71,7 @@ def convert(args):
         kwargs["float_fmt"] = args.float_format
     if args.ascii:
         kwargs["binary"] = False
+    else:
+        kwargs["binary"] = True
 
     write(args.outfile, mesh, **kwargs)


### PR DESCRIPTION
If not set the The ["binary"] = True, write function cannot write  binary mode,
For example: stl will never output binary format.  Code location: src.meshio.stl._stl.write; src.meshio.mdpa._mdpa.write