### PR TITLE
Change error to warning in vtu and skip field

### DIFF
--- a/src/meshio/_cli/_ascii.py
+++ b/src/meshio/_cli/_ascii.py
@@ -1,6 +1,5 @@
 import os
 import pathlib
-import glob
 
 from .. import ansys, flac3d, gmsh, mdpa, ply, stl, vtk, vtu, xdmf
 from .._common import error
@@ -8,8 +7,6 @@ from .._helpers import _filetypes_from_path, read, reader_map
 
 
 def add_args(parser):
-    parser.add_argument("infile", type=str, help="mesh file to convert")
-
     parser.add_argument(
         "--input-format",
         "-i",
@@ -19,9 +16,14 @@ def add_args(parser):
         default=None,
     )
 
+    parser.add_argument("infile", type=str, nargs='*', help="mesh file to convert")
+
 
 def ascii(args):
-    for file in glob.glob(args.infile):
+    if not isinstance(args.infile, list):
+        args.infile = [args.infile]
+
+    for file in args.infile:
         if args.input_format:
             fmts = [args.input_format]
         else:

--- a/src/meshio/_cli/_ascii.py
+++ b/src/meshio/_cli/_ascii.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import glob
 
 from .. import ansys, flac3d, gmsh, mdpa, ply, stl, vtk, vtu, xdmf
 from .._common import error
@@ -20,43 +21,44 @@ def add_args(parser):
 
 
 def ascii(args):
-    if args.input_format:
-        fmts = [args.input_format]
-    else:
-        fmts = _filetypes_from_path(pathlib.Path(args.infile))
-    # pick the first
-    fmt = fmts[0]
+    for file in glob.glob(args.infile):
+        if args.input_format:
+            fmts = [args.input_format]
+        else:
+            fmts = _filetypes_from_path(pathlib.Path(file))
+        # pick the first
+        fmt = fmts[0]
 
-    size = os.stat(args.infile).st_size
-    print(f"File size before: {size / 1024 ** 2:.2f} MB")
-    mesh = read(args.infile, file_format=args.input_format)
+        size = os.stat(file).st_size
+        print(f"File size before: {size / 1024 ** 2:.2f} MB")
+        mesh = read(file, file_format=args.input_format)
 
-    # # Some converters (like VTK) require `points` to be contiguous.
-    # mesh.points = np.ascontiguousarray(mesh.points)
+        # # Some converters (like VTK) require `points` to be contiguous.
+        # mesh.points = np.ascontiguousarray(mesh.points)
 
-    # write it out
-    if fmt == "ansys":
-        ansys.write(args.infile, mesh, binary=False)
-    elif fmt == "flac3d":
-        flac3d.write(args.infile, mesh, binary=False)
-    elif fmt == "gmsh":
-        gmsh.write(args.infile, mesh, binary=False)
-    elif fmt == "mdpa":
-        mdpa.write(args.infile, mesh, binary=False)
-    elif fmt == "ply":
-        ply.write(args.infile, mesh, binary=False)
-    elif fmt == "stl":
-        stl.write(args.infile, mesh, binary=False)
-    elif fmt == "vtk":
-        vtk.write(args.infile, mesh, binary=False)
-    elif fmt == "vtu":
-        vtu.write(args.infile, mesh, binary=False)
-    elif fmt == "xdmf":
-        xdmf.write(args.infile, mesh, data_format="XML")
-    else:
-        error(f"Don't know how to convert {args.infile} to ASCII format.")
-        return 1
+        # write it out
+        if fmt == "ansys":
+            ansys.write(file, mesh, binary=False)
+        elif fmt == "flac3d":
+            flac3d.write(file, mesh, binary=False)
+        elif fmt == "gmsh":
+            gmsh.write(file, mesh, binary=False)
+        elif fmt == "mdpa":
+            mdpa.write(file, mesh, binary=False)
+        elif fmt == "ply":
+            ply.write(file, mesh, binary=False)
+        elif fmt == "stl":
+            stl.write(file, mesh, binary=False)
+        elif fmt == "vtk":
+            vtk.write(file, mesh, binary=False)
+        elif fmt == "vtu":
+            vtu.write(file, mesh, binary=False)
+        elif fmt == "xdmf":
+            xdmf.write(file, mesh, data_format="XML")
+        else:
+            error(f"Don't know how to convert {file} to ASCII format.")
+            return 1
 
-    size = os.stat(args.infile).st_size
-    print(f"File size after: {size / 1024 ** 2:.2f} MB")
-    return 0
+        size = os.stat(file).st_size
+        print(f"File size after: {size / 1024 ** 2:.2f} MB")
+        return 0

--- a/src/meshio/_cli/_binary.py
+++ b/src/meshio/_cli/_binary.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import glob
 
 from .. import ansys, flac3d, gmsh, mdpa, ply, stl, vtk, vtu, xdmf
 from .._helpers import _filetypes_from_path, read, reader_map
@@ -19,42 +20,43 @@ def add_args(parser):
 
 
 def binary(args):
-    if args.input_format:
-        fmts = [args.input_format]
-    else:
-        fmts = _filetypes_from_path(pathlib.Path(args.infile))
-    # pick the first
-    fmt = fmts[0]
+    for file in glob.glob(args.infile):
+        if args.input_format:
+            fmts = [args.input_format]
+        else:
+            fmts = _filetypes_from_path(pathlib.Path(file))
+        # pick the first
+        fmt = fmts[0]
 
-    size = os.stat(args.infile).st_size
-    print(f"File size before: {size / 1024 ** 2:.2f} MB")
-    mesh = read(args.infile, file_format=args.input_format)
+        size = os.stat(file).st_size
+        print(f"File size before: {size / 1024 ** 2:.2f} MB")
+        mesh = read(file, file_format=args.input_format)
 
-    # # Some converters (like VTK) require `points` to be contiguous.
-    # mesh.points = np.ascontiguousarray(mesh.points)
+        # # Some converters (like VTK) require `points` to be contiguous.
+        # mesh.points = np.ascontiguousarray(mesh.points)
 
-    # write it out
-    if fmt == "ansys":
-        ansys.write(args.infile, mesh, binary=True)
-    elif fmt == "flac3d":
-        flac3d.write(args.infile, mesh, binary=True)
-    elif fmt == "gmsh":
-        gmsh.write(args.infile, mesh, binary=True)
-    elif fmt == "mdpa":
-        mdpa.write(args.infile, mesh, binary=True)
-    elif fmt == "ply":
-        ply.write(args.infile, mesh, binary=True)
-    elif fmt == "stl":
-        stl.write(args.infile, mesh, binary=True)
-    elif fmt == "vtk":
-        vtk.write(args.infile, mesh, binary=True)
-    elif fmt == "vtu":
-        vtu.write(args.infile, mesh, binary=True)
-    elif fmt == "xdmf":
-        xdmf.write(args.infile, mesh, data_format="HDF")
-    else:
-        print(f"Don't know how to convert {args.infile} to binary format.")
-        exit(1)
+        # write it out
+        if fmt == "ansys":
+            ansys.write(file, mesh, binary=True)
+        elif fmt == "flac3d":
+            flac3d.write(file, mesh, binary=True)
+        elif fmt == "gmsh":
+            gmsh.write(file, mesh, binary=True)
+        elif fmt == "mdpa":
+            mdpa.write(file, mesh, binary=True)
+        elif fmt == "ply":
+            ply.write(file, mesh, binary=True)
+        elif fmt == "stl":
+            stl.write(file, mesh, binary=True)
+        elif fmt == "vtk":
+            vtk.write(file, mesh, binary=True)
+        elif fmt == "vtu":
+            vtu.write(file, mesh, binary=True)
+        elif fmt == "xdmf":
+            xdmf.write(file, mesh, data_format="HDF")
+        else:
+            print(f"Don't know how to convert {file} to binary format.")
+            exit(1)
 
-    size = os.stat(args.infile).st_size
-    print(f"File size after: {size / 1024 ** 2:.2f} MB")
+        size = os.stat(file).st_size
+        print(f"File size after: {size / 1024 ** 2:.2f} MB")

--- a/src/meshio/_cli/_binary.py
+++ b/src/meshio/_cli/_binary.py
@@ -20,6 +20,9 @@ def add_args(parser):
 
 
 def binary(args):
+    print(glob.glob(args.infile))
+    print("\n\n")
+    print(args.infile)
     for file in glob.glob(args.infile):
         if args.input_format:
             fmts = [args.input_format]

--- a/src/meshio/_cli/_binary.py
+++ b/src/meshio/_cli/_binary.py
@@ -1,13 +1,11 @@
 import os
 import pathlib
-import glob
 
 from .. import ansys, flac3d, gmsh, mdpa, ply, stl, vtk, vtu, xdmf
 from .._helpers import _filetypes_from_path, read, reader_map
 
 
 def add_args(parser):
-    parser.add_argument("infile", type=str, help="mesh file to convert")
 
     parser.add_argument(
         "--input-format",
@@ -18,12 +16,15 @@ def add_args(parser):
         default=None,
     )
 
+    parser.add_argument("infile", type=str, nargs='*', help="mesh file to convert")
 
+
+    
 def binary(args):
-    print(glob.glob(args.infile))
-    print("\n\n")
-    print(args.infile)
-    for file in glob.glob(args.infile):
+    if not isinstance(args.infile, list):
+        args.infile = [args.infile]
+
+    for file in args.infile:
         if args.input_format:
             fmts = [args.input_format]
         else:

--- a/src/meshio/_cli/_compress.py
+++ b/src/meshio/_cli/_compress.py
@@ -7,7 +7,6 @@ from .._helpers import _filetypes_from_path, read, reader_map
 
 
 def add_args(parser):
-    parser.add_argument("infile", type=str, help="mesh file to compress")
     parser.add_argument(
         "--input-format",
         "-i",
@@ -23,59 +22,65 @@ def add_args(parser):
         help="maximum compression",
         default=False,
     )
+    parser.add_argument("infile", type=str, nargs='*', help="mesh file to compress")
 
 
 def compress(args):
-    if args.input_format:
-        fmts = [args.input_format]
-    else:
-        fmts = _filetypes_from_path(pathlib.Path(args.infile))
-    # pick the first
-    fmt = fmts[0]
+    if not isinstance(args.infile, list):
+        args.infile = [args.infile]
 
-    size = os.stat(args.infile).st_size
-    print(f"File size before: {size / 1024 ** 2:.2f} MB")
-    mesh = read(args.infile, file_format=args.input_format)
+    for file in args.infile:
 
-    # # Some converters (like VTK) require `points` to be contiguous.
-    # mesh.points = np.ascontiguousarray(mesh.points)
+        if args.input_format:
+            fmts = [args.input_format]
+        else:
+            fmts = _filetypes_from_path(pathlib.Path(file))
+        # pick the first
+        fmt = fmts[0]
 
-    # write it out
-    if fmt == "ansys":
-        ansys.write(args.infile, mesh, binary=True)
-    elif fmt == "cgns":
-        cgns.write(
-            args.infile, mesh, compression="gzip", compression_opts=9 if args.max else 4
-        )
-    elif fmt == "gmsh":
-        gmsh.write(args.infile, mesh, binary=True)
-    elif fmt == "h5m":
-        h5m.write(
-            args.infile, mesh, compression="gzip", compression_opts=9 if args.max else 4
-        )
-    elif fmt == "mdpa":
-        mdpa.write(args.infile, mesh, binary=True)
-    elif fmt == "ply":
-        ply.write(args.infile, mesh, binary=True)
-    elif fmt == "stl":
-        stl.write(args.infile, mesh, binary=True)
-    elif fmt == "vtk":
-        vtk.write(args.infile, mesh, binary=True)
-    elif fmt == "vtu":
-        vtu.write(
-            args.infile, mesh, binary=True, compression="lzma" if args.max else "zlib"
-        )
-    elif fmt == "xdmf":
-        xdmf.write(
-            args.infile,
-            mesh,
-            data_format="HDF",
-            compression="gzip",
-            compression_opts=9 if args.max else 4,
-        )
-    else:
-        error(f"Don't know how to compress {args.infile}.")
-        exit(1)
+        size = os.stat(file).st_size
+        print(f"File size before: {size / 1024 ** 2:.2f} MB")
+        mesh = read(file, file_format=args.input_format)
 
-    size = os.stat(args.infile).st_size
-    print(f"File size after: {size / 1024 ** 2:.2f} MB")
+        # # Some converters (like VTK) require `points` to be contiguous.
+        # mesh.points = np.ascontiguousarray(mesh.points)
+
+        # write it out
+        if fmt == "ansys":
+            ansys.write(file, mesh, binary=True)
+        elif fmt == "cgns":
+            cgns.write(
+                file, mesh, compression="gzip", compression_opts=9 if args.max else 4
+            )
+        elif fmt == "gmsh":
+            gmsh.write(file, mesh, binary=True)
+        elif fmt == "h5m":
+            h5m.write(
+                file, mesh, compression="gzip", compression_opts=9 if args.max else 4
+            )
+        elif fmt == "mdpa":
+            mdpa.write(file, mesh, binary=True)
+        elif fmt == "ply":
+            ply.write(file, mesh, binary=True)
+        elif fmt == "stl":
+            stl.write(file, mesh, binary=True)
+        elif fmt == "vtk":
+            vtk.write(file, mesh, binary=True)
+        elif fmt == "vtu":
+            vtu.write(
+                file, mesh, binary=True, compression="lzma" if args.max else "zlib"
+            )
+        elif fmt == "xdmf":
+            xdmf.write(
+                file,
+                mesh,
+                data_format="HDF",
+                compression="gzip",
+                compression_opts=9 if args.max else 4,
+            )
+        else:
+            error(f"Don't know how to compress {file}.")
+            exit(1)
+
+        size = os.stat(file).st_size
+        print(f"File size after: {size / 1024 ** 2:.2f} MB")

--- a/src/meshio/vtu/_vtu.py
+++ b/src/meshio/vtu/_vtu.py
@@ -416,6 +416,7 @@ class VtuReader:
                     cell_data_raw.append(piece_cell_data_raw)
                 else:
                     print(f"Warning: Ignoring unknown tag '{child.tag}' in vtu.")
+                    
 
         if not cell_data_raw:
             cell_data_raw = [{}] * len(cells)

--- a/src/meshio/vtu/_vtu.py
+++ b/src/meshio/vtu/_vtu.py
@@ -62,7 +62,7 @@ def _polyhedron_cells_from_data(offsets, faces, faceoffsets, cell_data_raw):
             num_nodes_this_face = faces[next_face]
             faces_this_cell.append(
                 np.array(
-                    faces[next_face + 1 : (next_face + num_nodes_this_face + 1)],
+                    faces[next_face + 1: (next_face + num_nodes_this_face + 1)],
                     dtype=int,
                 )
             )
@@ -227,9 +227,9 @@ def _parse_raw_binary(filename):
                 raise RuntimeError(f"Could not find .//DataArray[@offset='{i}']")
             da_tag.set("offset", str(len(arrays)))
 
-            block_size = int(np.frombuffer(data[i : i + dtype.itemsize], dtype)[0])
+            block_size = int(np.frombuffer(data[i: i + dtype.itemsize], dtype)[0])
             arrays += base64.b64encode(
-                data[i : i + block_size + dtype.itemsize]
+                data[i: i + block_size + dtype.itemsize]
             ).decode()
             i += block_size + dtype.itemsize
 
@@ -245,10 +245,10 @@ def _parse_raw_binary(filename):
             assert da_tag is not None
             da_tag.set("offset", str(len(arrays)))
 
-            num_blocks = int(np.frombuffer(data[i : i + dtype.itemsize], dtype)[0])
+            num_blocks = int(np.frombuffer(data[i: i + dtype.itemsize], dtype)[0])
             num_header_items = 3 + num_blocks
             num_header_bytes = num_header_items * dtype.itemsize
-            header = np.frombuffer(data[i : i + num_header_bytes], dtype)
+            header = np.frombuffer(data[i: i + num_header_bytes], dtype)
 
             block_data = b""
             j = 0
@@ -256,7 +256,7 @@ def _parse_raw_binary(filename):
                 block_size = int(header[k + 3])
                 block_data += c.decompress(
                     data[
-                        i + j + num_header_bytes : i + j + block_size + num_header_bytes
+                        i + j + num_header_bytes: i + j + block_size + num_header_bytes
                     ]
                 )
                 j += block_size
@@ -415,7 +415,7 @@ class VtuReader:
 
                     cell_data_raw.append(piece_cell_data_raw)
                 else:
-                    raise ReadError(f"Unknown tag '{child.tag}'.")
+                    print(f"Warning: Ignoring unknown tag '{child.tag}' in vtu.")
 
         if not cell_data_raw:
             cell_data_raw = [{}] * len(cells)
@@ -514,7 +514,7 @@ class VtuReader:
         block_data = np.concatenate(
             [
                 np.frombuffer(
-                    c.decompress(byte_array[byte_offsets[k] : byte_offsets[k + 1]]),
+                    c.decompress(byte_array[byte_offsets[k]: byte_offsets[k + 1]]),
                     dtype=dtype,
                 )
                 for k in range(num_blocks)
@@ -586,7 +586,7 @@ def read(filename):
 def _chunk_it(array, n):
     k = 0
     while k * n < len(array):
-        yield array[k * n : (k + 1) * n]
+        yield array[k * n: (k + 1) * n]
         k += 1
 
 


### PR DESCRIPTION
Sometimes extra data is found in the vtu files and can be either handled or ignored. Substituted the Error raised by a warning to be able to run the rest and get the data.