### PR TITLE
[bug] Fix STL _write_ascii to use proper format

### DIFF
--- a/src/meshio/stl/_stl.py
+++ b/src/meshio/stl/_stl.py
@@ -210,7 +210,7 @@ def write(filename, mesh, binary=False):
 
 def _write_ascii(filename, pts, normals):
     with open_file(filename, "w") as fh:
-        fh.write("solid\n")
+        fh.write("solid \n")
         for local_pts, normal in zip(pts, normals):
             out = (
                 "\n".join(


### PR DESCRIPTION
Currently the _write_ascii function in stl.py prints the first line with a newline immediately after solid. Please note the bold section in the following specification:

"An ASCII STL file begins with the line:

`solid name`

where name is an optional string (**though if name is omitted there must still be a space after solid,** for compatibility with some software)."

[Source](https://en.wikipedia.org/wiki/STL_(file_format))

Some STL programs cannot read the current format provided by meshio.