### PR TITLE
xdmf: XML is default Format for DataItem

### DIFF
--- a/src/meshio/xdmf/main.py
+++ b/src/meshio/xdmf/main.py
@@ -79,7 +79,7 @@ class XdmfReader:
             data_type = "Float"
 
         precision = data_item.get("Precision", default="4")
-        fmt = data_item.attrib["Format"]
+        fmt = data_item.get("Format", default="XML")
 
         if fmt == "XML":
             dtype = xdmf_to_numpy_type[(data_type, precision)]


### PR DESCRIPTION
According to [Default XML Attributes](https://www.xdmf.org/index.php/XDMF_Model_and_Format#XML_Element_(Xdmf_ClassName)_and_Default_XML_Attributes) `Format=XML` should be the default for `DataItem` element. This is a valid XDMF file

```XML
$ cat tri.xdmf
<Xdmf
    Version="2">
  <Domain>
    <Grid>
      <Topology
	  TopologyType="Triangle"
	  Dimensions="1">
	<DataItem
	    Dimensions="1 3"
	    NumberType="Int">
	  0 1 2
	</DataItem>
      </Topology>
      <Geometry>
	<DataItem
	    Dimensions="3 3">
	  0 0 0
	  1 0 0
	  0 1 0
	</DataItem>
      </Geometry>
    </Grid>
  </Domain>
</Xdmf>
```

and `meshio info`  returns after applying the modification.
```shell
$ meshio info tri.xdmf 
<meshio mesh object>
  Number of points: 3
  Number of cells:
    triangle: 1
```

