### PR TITLE
Patch for len of float assertion error in nastran

### DIFF
--- a/src/meshio/nastran/_nastran.py
+++ b/src/meshio/nastran/_nastran.py
@@ -407,9 +407,9 @@ def _float_to_nastran_string(value, length=16):
     Examples:
         1234.56789 --> "1.23456789E+3"
         -0.1234 --> "-1.234E-1"
-        3.1415926535897932 --> "3.14159265359E+0"
+        3.1415926535897932 --> "3.141592653E+0"
     """
-    out = np.format_float_scientific(value, exp_digits=1, precision=11).replace(
+    out = np.format_float_scientific(value, exp_digits=1, precision=9).replace(
         "e", "E"
     )
     assert len(out) <= 16


### PR DESCRIPTION
I recently tried to convert a mesh and ran into an assertion error in `_float_to_nastran_string`.

To reproduce the bug

```python
from meshio.nastran._nastran import _float_to_nastran_string

_float_to_nastran_string(-1.5614246689128802e-18)
```

```
Traceback (most recent call last):
  File "/home/remidm/festim-review/comparison/achlys/convert_mesh.py", line 27, in <module>
    _float_to_nastran_string(-1.5614246689128802e-18)
  File "/home/remidm/miniconda3/envs/festim/lib/python3.11/site-packages/meshio/nastran/_nastran.py", line 416, in _float_to_nastran_string
    assert len(out) <= 16
           ^^^^^^^^^^^^^^
AssertionError
```

The value of `out` is `-1.56142466891E-18` which is 18 characters long.

This PR reduces the precision argument in  `format_float_scientific` to 9 and fixes the bug.

ping @gabriele-ferrero

