### PR TITLE
[VTK5.1] Store mesh independent field data

### DIFF
--- a/src/meshio/vtk/_vtk_51.py
+++ b/src/meshio/vtk/_vtk_51.py
@@ -199,9 +199,12 @@ def _read_subsection(f, info):
     elif info.active == "CELL_DATA":
         d = info.cell_data_raw
     elif info.active == "DATASET":
-        d = info.dataset
+        if info.section == "FIELD": # Put general field data in field_data
+            d = info.field_data
+        else:
+            d = info.dataset
     else:
-        d = info.field_data
+        raise ReadError(f"Unknown section '{info.section}' inside '{info.active}'.")
 
     if info.section in vtk_dataset_infos[info.dataset["type"]]:
         if info.section[1:] == "_COORDINATES":
@@ -534,6 +537,9 @@ def write(filename, mesh, binary=True):
         f.write(f"written by meshio v{__version__}\n".encode())
         f.write(("BINARY\n" if binary else "ASCII\n").encode())
         f.write(b"DATASET UNSTRUCTURED_GRID\n")
+
+        # write field data
+        _write_field_data(f, mesh.field_data, binary)
 
         # write points and cells
         _write_points(f, points, binary)


### PR DESCRIPTION
Fixes #1446 
I choose a minimally "invasive" approach to support storing mesh independent field data. The idea behind my pull request is to capture independent `FIELD`s in `field_data` while still storing mesh-related attributes in `dataset`.

@nschloe: I am not sure if the usage of the field_data attribute aligns with the usage in the other mesh format. Maybe you can give some feedback.