### PR TITLE
[(Xdmf)TimeSeriesWriter] Store h5 file at same location as xdmf file

### DIFF
--- a/src/meshio/xdmf/time_series.py
+++ b/src/meshio/xdmf/time_series.py
@@ -262,7 +262,7 @@ class TimeSeriesWriter:
         if self.data_format == "HDF":
             import h5py
 
-            self.h5_filename = self.filename.stem + ".h5"
+            self.h5_filename = self.filename.with_suffix(".h5")
             self.h5_file = h5py.File(self.h5_filename, "w")
         return self
 

--- a/tests/test_xdmf.py
+++ b/tests/test_xdmf.py
@@ -60,9 +60,8 @@ def test_generic_io(tmp_path):
     helpers.generic_io(tmp_path / "test.0.xdmf")
 
 
-def test_time_series():
-    # write the data
-    filename = "out.xdmf"
+def test_time_series(tmp_path):
+    filename = tmp_path / "out.xdmf"
 
     with meshio.xdmf.TimeSeriesWriter(filename) as writer:
         writer.write_points_cells(helpers.tri_mesh_2d.points, helpers.tri_mesh_2d.cells)


### PR DESCRIPTION
Fixes #1442 
Modifies the existing TimeSeriesWriter test case to use a temporary subdirectory.