### PR TITLE
Fix/xdmf time series writer lines

### DIFF
--- a/src/meshio/xdmf/time_series.py
+++ b/src/meshio/xdmf/time_series.py
@@ -410,7 +410,7 @@ class TimeSeriesWriter:
             # number of nodes. Hence, prepend 2.
             for c in cell_blocks:
                 if c.type == "line":
-                    c.data[:] = np.insert(c.data, 0, 2, axis=1)
+                    c.data = np.insert(c.data, 0, 2, axis=1)
                     dim += len(c.data)
             dim = str(dim)
             cd = np.concatenate(

--- a/tests/test_xdmf.py
+++ b/tests/test_xdmf.py
@@ -6,7 +6,7 @@ import meshio
 from . import helpers
 
 test_set_full = [
-    #helpers.empty_mesh,
+    helpers.empty_mesh,
     helpers.line_mesh,
     helpers.tri_mesh,
     helpers.line_tri_mesh,
@@ -59,7 +59,7 @@ def test_generic_io(tmp_path):
     # With additional, insignificant suffix:
     helpers.generic_io(tmp_path / "test.0.xdmf")
 
-@pytest.mark.parametrize("mesh", test_set_full)
+@pytest.mark.parametrize("mesh", [mesh for mesh in test_set_full if mesh != helpers.empty_mesh])
 def test_time_series(mesh):
     # write the data
     filename = "out.xdmf"


### PR DESCRIPTION
Fixes #1462 and  #1398

The changes are backed by the expanded test coverage. However, I removed the `empty_mesh` like it was done in most other tests already before. I also tested whether the output files are valid by opening them in paraview.