### PR TITLE
netgen - skip 'facedescriptors' and 'face_transparencies' blocks

### DIFF
--- a/src/meshio/netgen/_netgen.py
+++ b/src/meshio/netgen/_netgen.py
@@ -312,6 +312,8 @@ def read_buffer(f):
 
         elif line in [
             "face_colours",
+            "face_transparencies",
+            "facedescriptors",
             "singular_edge_left",
             "singular_edge_right",
             "singular_face_inside",


### PR DESCRIPTION
Netgen has new fields in the mesh data, just skip it when parsing.