### PR TITLE
Tecplot writer improvements

### DIFF
--- a/src/meshio/tecplot/_tecplot.py
+++ b/src/meshio/tecplot/_tecplot.py
@@ -494,7 +494,9 @@ def write(filename, mesh, ncol=20, data_formats={}):
 
         # Zone data
         for i, arr in enumerate(data):
-            _write_table(f, arr, ncol=ncol, data_format=data_formats.get(variables[i], ""))
+            _write_table(
+                f, arr, ncol=ncol, data_format=data_formats.get(variables[i], "")
+            )
 
         # CellBlock
         for cell in cells:

--- a/src/meshio/tecplot/_tecplot.py
+++ b/src/meshio/tecplot/_tecplot.py
@@ -377,6 +377,10 @@ def _read_zone_data(f, num_data, num_cells, zone_format):
 
 
 def write(filename, mesh, ncol=20, data_formats={}):
+    # ncol is the number of columns for saving the data
+    # data_formats is an optional dict containing a string format
+    # for every data variable (used as key), e.g. {"X": ".5f"}
+
     # Check cell types
     cell_types = []
     cell_blocks = []
@@ -490,7 +494,6 @@ def write(filename, mesh, ncol=20, data_formats={}):
 
         # Zone data
         for i, arr in enumerate(data):
-            # Try to get format from dict, otherwise return empty str ""
             _write_table(f, arr, ncol=ncol, data_format=data_formats.get(variables[i], ""))
 
         # CellBlock

--- a/src/meshio/tecplot/_tecplot.py
+++ b/src/meshio/tecplot/_tecplot.py
@@ -376,7 +376,7 @@ def _read_zone_data(f, num_data, num_cells, zone_format):
     return data, np.concatenate(cells)
 
 
-def write(filename, mesh):
+def write(filename, mesh, ncol=20, data_formats={}):
     # Check cell types
     cell_types = []
     cell_blocks = []
@@ -489,20 +489,21 @@ def write(filename, mesh):
             f.write("\n")
 
         # Zone data
-        for arr in data:
-            _write_table(f, arr)
+        for i, arr in enumerate(data):
+            # Try to get format from dict, otherwise return empty str ""
+            _write_table(f, arr, ncol=ncol, data_format=data_formats.get(variables[i], ""))
 
         # CellBlock
         for cell in cells:
             f.write(" ".join(str(c) for c in cell + 1) + "\n")
 
 
-def _write_table(f, data, ncol=20):
+def _write_table(f, data, ncol=20, data_format=""):
     nrow = len(data) // ncol
     lines = np.split(data, np.full(nrow, ncol).cumsum())
     for line in lines:
         if len(line):
-            f.write(" ".join(str(l) for l in line) + "\n")
+            f.write(" ".join(format(l, data_format) for l in line) + "\n")
 
 
 register_format("tecplot", [".dat", ".tec"], read, {"tecplot": write})


### PR DESCRIPTION
Hi, in the tecplot module there was an `ncol` option in the table table writer function which was not being considered in the main writer, so I implemented this as an extra keyword option. I also added an optional kw where a dictionary can be passed to format the numerical data, for every data variable in the mesh. For instance, `data_formats={"X": ".4f"}`. The default option is to not format the data, as the original code works.