### PR TITLE
update xdmf_idx_to_num_nodes for triangle6

### DIFF
--- a/src/meshio/xdmf/common.py
+++ b/src/meshio/xdmf/common.py
@@ -124,7 +124,8 @@ def translate_mixed_cells(data):
         7: 5,  # pyramid
         8: 6,  # wedge
         9: 8,  # hex
-        11: 6,  # triangle6
+        11: 6,  # triangle6 (I don't know where this 11 is comming from...leaving it, since it does no harm)
+        36: 6,  # triangle6
     }
 
     # collect types and offsets


### PR DESCRIPTION
I need meshio for xdmf with quadratic triangle with 6 nodes. 
this is 0x24: "triangle6" or 36 in decimal as written in the xdmf_idx_to_meshio_type dict in https://github.com/nschloe/meshio/blob/b2ee99842e119901349fdeee06b5bf61e01f450a/src/meshio/xdmf/common.py#L36
