### PR TITLE
Fix vtk51 format actually referring to VTK 5.1

### DIFF
--- a/src/meshio/vtk/_main.py
+++ b/src/meshio/vtk/_main.py
@@ -40,7 +40,7 @@ register_format(
     read,
     {
         "vtk42": _vtk_42.write,
-        "vtk51": _vtk_42.write,
+        "vtk51": _vtk_51.write,
         "vtk": _vtk_51.write,
     },
 )


### PR DESCRIPTION
Hey, found this whilst resolving a bug

It's been there for 3+ years, so it is up to whoever to approve this or just leave it.
