### PR TITLE
Add capability to read exodus files with time-varying data

### DIFF
--- a/src/meshio/_mesh.py
+++ b/src/meshio/_mesh.py
@@ -13,6 +13,7 @@ topological_dimension = {
     "triangle": 2,
     "quad": 2,
     "tetra": 3,
+    "tetra4": 3,
     "hexahedron": 3,
     "wedge": 3,
     "pyramid": 3,

--- a/src/meshio/exodus/_exodus.py
+++ b/src/meshio/exodus/_exodus.py
@@ -291,6 +291,12 @@ def write(filename, mesh):
     import netCDF4
 
     with netCDF4.Dataset(filename, "w") as rootgrp:
+        # if time-dependent, pass in mesh and time_step as list
+        if type(mesh) is list:
+            mesh, time_step = mesh
+        else:
+            time_step = None
+
         # set global data
         now = datetime.datetime.now().isoformat()
         rootgrp.title = f"Created by meshio v{__version__}, {now}"
@@ -308,7 +314,7 @@ def write(filename, mesh):
         rootgrp.createDimension("len_string", 33)
         rootgrp.createDimension("len_line", 81)
         rootgrp.createDimension("four", 4)
-        rootgrp.createDimension("time_step", None)
+        rootgrp.createDimension("time_step", time_step)
 
         # dummy time step
         data = rootgrp.createVariable("time_whole", "f4", ("time_step",))
@@ -377,6 +383,9 @@ def write(filename, mesh):
                     fill_value=False,
                 )
                 node_data[0] = data
+                if time_step is not None:
+                    for time_index in range(1, time_step):
+                        node_data[time_index] = data
 
         # node sets
         num_point_sets = len(mesh.point_sets)

--- a/src/meshio/exodus/_exodus.py
+++ b/src/meshio/exodus/_exodus.py
@@ -15,7 +15,7 @@ from ..__about__ import __version__
 from .._common import warn
 from .._exceptions import ReadError
 from .._helpers import register_format
-from .._mesh import Mesh
+from .._mesh import Mesh, CellBlock
 
 exodus_to_meshio_type = {
     "SPHERE": "vertex",
@@ -85,10 +85,15 @@ def read(filename):  # noqa: C901
         cd = {}
         cells = []
         ns_names = []
-        # eb_names = []
+        eb_names = []
         ns = []
         point_sets = {}
         info = []
+
+        for key, value in nc.variables.items():
+            if key == "eb_names":
+                value.set_auto_mask(False)
+                eb_names = [b"".join(c).decode("UTF-8") for c in value[:]]
 
         for key, value in nc.variables.items():
             if key == "info_records":
@@ -136,9 +141,12 @@ def read(filename):  # noqa: C901
                 value.set_auto_mask(False)
 
                 # loop over all value (equal to timesteps)
-                cd[idx] = []
+                if idx not in cd:
+                    cd[idx] = []
+
                 for t, val in enumerate(value):
-                    cd[idx].append({})
+                    if block == 0:
+                        cd[idx].append({})
                     cd[idx][t][block] = val
             elif key == "ns_names":
                 value.set_auto_mask(False)
@@ -148,12 +156,6 @@ def read(filename):  # noqa: C901
             #     eb_names = [b"".join(c).decode("UTF-8") for c in value[:]]
             elif key.startswith("node_ns"):  # Expected keys: node_ns1, node_ns2
                 ns.append(value[:] - 1)  # Exodus is 1-based
-
-        # merge element block data; can't handle blocks yet
-        for k, value in cd.items():
-            # merge element block data; can't handle blocks yet
-            for t in range(len(value)):
-                cd[k][t] = np.concatenate(list(value[t].values()))
 
 
         # Check if there are any <name>R, <name>Z tuples or <name>X, <name>Y, <name>Z
@@ -190,25 +192,36 @@ def read(filename):  # noqa: C901
                 point_data[name] = np.column_stack([pd0_t, pd1_t, pd2_t])
 
         cell_data = {}
-        k = 0
-        for _, cell in cells:
-            n = len(cell)
-            for name_base, (idx, data) in zip(cell_data_names, cd.items()):
-                for t, data_per_time in enumerate(data):
+        for name_base, (idx, data) in zip(cell_data_names, cd.items()):
+            for t, data_per_time in enumerate(data):
+                for b, (_, cell) in enumerate(cells):
                     if len(data) > 1:
                         name = f"{name_base}_time{t}"
                     else:
                         name = name_base
                     if name not in cell_data:
                         cell_data[name] = []
-                    cell_data[name].append(data_per_time[k : k + n])
-            k += n
+                    cell_data[name].append(data_per_time[b])
 
         point_sets = {name: dat for name, dat in zip(ns_names, ns)}
 
+        # Format data into CellBlock with block name as a tag
+        out_cells = []
+        for cell_block, block_name in zip(cells, eb_names):
+            if isinstance(cell_block, tuple):
+                cell_type, data = cell_block
+                cell_block = CellBlock(
+                    cell_type,
+                    # polyhedron data cannot be converted to numpy arrays
+                    # because the sublists don't all have the same length
+                    data if cell_type.startswith("polyhedron") else np.asarray(data),
+                    tags=[block_name]
+                )
+            out_cells.append(cell_block)
+
     return Mesh(
         points,
-        cells,
+        out_cells,
         point_data=point_data,
         cell_data=cell_data,
         point_sets=point_sets,

--- a/tests/test_exodus.py
+++ b/tests/test_exodus.py
@@ -23,6 +23,7 @@ test_set = [
     helpers.add_point_data(helpers.tri_mesh, 2),
     helpers.add_point_data(helpers.tri_mesh, 3),
     helpers.add_cell_data(helpers.tri_mesh, [("a", (3,), np.float64)]),
+    helpers.add_timevarying_point_data(helpers.tri_mesh, 1, 2),
     helpers.add_point_sets(helpers.tri_mesh),
     helpers.add_point_sets(helpers.tet_mesh),
 ]

--- a/tests/test_exodus.py
+++ b/tests/test_exodus.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import meshio
@@ -21,6 +22,7 @@ test_set = [
     helpers.add_point_data(helpers.tri_mesh, 1),
     helpers.add_point_data(helpers.tri_mesh, 2),
     helpers.add_point_data(helpers.tri_mesh, 3),
+    helpers.add_cell_data(helpers.tri_mesh, [("a", (3,), np.float64)]),
     helpers.add_point_sets(helpers.tri_mesh),
     helpers.add_point_sets(helpers.tet_mesh),
 ]


### PR DESCRIPTION
Hi,

I have added code to read exodus files with time-varying data. 

A field "a" that contains "values" of length T previously returned values[0]. Now, if len(values) > 1, new fields are created such as ["a_time0", "a_time1", ..., "a_timeT"]. This has been implemented for point data and cell data. 

I added a unit test for cell_data (not time-dependent), and also for time-varying point_data. The latter was a bit trickier, I couldn't find out how to create time-varying data in the `in_mesh` object. So instead, exodus.write, will write the same value for each step. This is just so the unit-test can check that *something* is being written. This is probably not the best thing to do, but it seems the data cannot be viewed in paraview anyway, so we could consider adding a warning to use xdmf for writing time-dependent data. 

Thanks for developing this great tool.
Josh