### PR TITLE
Add `py.typed` file to mark `meshio` as partially typed

### DIFF
--- a/src/meshio/py.typed
+++ b/src/meshio/py.typed
@@ -1,0 +1,1 @@
+partial


### PR DESCRIPTION
Add `py.typed` to let type-checkers (e.g. mypy) know that the package is partially typed. See https://peps.python.org/pep-0561/#packaging-type-information

Without this, type-checkers treat everything as `Any`

With `py.typed`:
``` python
from meshio import Mesh
reveal_type(Mesh)  # note: Revealed type is "meshio._mesh.Mesh"
```

Without `py.typed`:
``` python
from meshio import Mesh
reveal_type(Mesh)  # note: Revealed type is "Any"
```
