### PR TITLE
Fix formatting output data with NumPy 2.x

### DIFF
--- a/src/meshio/dolfin/_dolfin.py
+++ b/src/meshio/dolfin/_dolfin.py
@@ -207,7 +207,7 @@ def _write_cell_data(filename, dim, cell_data):
     )
 
     for k, value in enumerate(cell_data):
-        ET.SubElement(mesh_function, "entity", index=str(k), value=repr(value))
+        ET.SubElement(mesh_function, "entity", index=str(k), value=str(value))
 
     tree = ET.ElementTree(dolfin)
     tree.write(filename)

--- a/src/meshio/gmsh/common.py
+++ b/src/meshio/gmsh/common.py
@@ -273,7 +273,7 @@ def _write_data(fh, tag, name, data, binary):
         tmp.tofile(fh)
         fh.write(b"\n")
     else:
-        fmt = " ".join(["{}"] + ["{!r}"] * num_components) + "\n"
+        fmt = " ".join(["{}"] * (num_components + 1)) + "\n"
         # TODO unify
         if num_components == 1:
             for k, x in enumerate(data):

--- a/src/meshio/mdpa/_mdpa.py
+++ b/src/meshio/mdpa/_mdpa.py
@@ -418,7 +418,7 @@ def _write_data(fh, tag, name, data, binary):
         data = data[:, 0]
 
     # Actually write the data
-    fmt = " ".join(["{}"] + ["{!r}"] * num_components) + "\n"
+    fmt = " ".join(["{}"] * (num_components + 1)) + "\n"
     # TODO unify
     if num_components == 1:
         for k, x in enumerate(data):

--- a/src/meshio/ugrid/_ugrid.py
+++ b/src/meshio/ugrid/_ugrid.py
@@ -145,7 +145,7 @@ def read_buffer(f, file_type):
 def _write_section(f, file_type, array, dtype):
     if file_type["type"] == "ascii":
         ncols = array.shape[1]
-        fmt = " ".join(["%r"] * ncols)
+        fmt = " ".join(["%s"] * ncols)
         np.savetxt(f, array, fmt=fmt)
     else:
         array.astype(dtype).tofile(f)


### PR DESCRIPTION
Fix the common `_write_data()` function to use a regular formatting rather than `repr()` when writing numbers to a file.  With NumPy 2.x, the latter resulted in literal `np.float64(…)` ending up in the data file.

Fixes #1499