### PR TITLE
Write scalars without type information (#1499)

### DIFF
--- a/src/meshio/_helpers.py
+++ b/src/meshio/_helpers.py
@@ -15,6 +15,11 @@ extension_to_filetypes = {}
 reader_map = {}
 _writer_map = {}
 
+# NumPy 2.x changed the representaion of scalars.
+# This reverts to the old behavior.
+# https://numpy.org/doc/2.2/release/2.0.0-notes.html#representation-of-numpy-scalars-changed
+if np.lib.NumpyVersion(np.__version__) >= '2.0.0':
+    np.set_printoptions(legacy="1.25")
 
 def register_format(
     format_name: str, extensions: list[str], reader, writer_map


### PR DESCRIPTION
NumPy 2.x changed the representation of scalaras including type
information. That lead to failing tests, since the test files were
written with the new representation (e.g. `np.int64(0)`).

This reverts to the old behavior of using plain `0`. Though, the actual
fix is likely to use `str()` or `f"{scalar!s}"` as described in the
release notes.
