### PR TITLE
fix(med): handle missing FAS section in MED reader

### DIFF
--- a/src/meshio/med/_med.py
+++ b/src/meshio/med/_med.py
@@ -74,10 +74,16 @@ def read(filename):
         point_data["point_tags"] = tags  # replacing previous "point_tags"
 
     # Information for point tags
+    # Not all MED files have FAS 
     point_tags = {}
-    fas = mesh["FAS"] if "FAS" in mesh else f["FAS"][mesh_name]
-    if "NOEUD" in fas:
-        point_tags = _read_families(fas["NOEUD"])
+    if "FAS" in mesh:        # first check for FAS in the mesh, then in the root group, since some MED files have FAS only in the root group
+        fas = mesh["FAS"]
+    elif "FAS" in f and mesh_name in f["FAS"]:
+        fas = f["FAS"][mesh_name]
+    else:
+        fas = None           # if FAS is not found, point_tags will be empty and the mesh.point_tags attribute will be an empty dict
+    if fas is not None and "NOEUD" in fas:
+        point_tags = _read_families(fas["NOEUD"]) 
 
     # CellBlock
     cells = []
@@ -99,7 +105,7 @@ def read(filename):
 
     # Information for cell tags
     cell_tags = {}
-    if "ELEME" in fas:
+    if fas is not None and "ELEME" in fas: 
         cell_tags = _read_families(fas["ELEME"])
 
     # Read nodal and cell data if they exist


### PR DESCRIPTION
- FAS section is not always present in MED files
- Replace unconditional access with a safe fallback to None
- Guard all fas usages with 'is not None' checks
- Prevents KeyError crash when FAS is absent from both mesh and root