### PR TITLE
Fix/med to gmsh metadata

### DIFF
--- a/src/meshio/gmsh/main.py
+++ b/src/meshio/gmsh/main.py
@@ -90,6 +90,7 @@ def _read_header(f):
 # meshio uses same precision but exponential notation `%.16e`.
 def write(filename, mesh, fmt_version="4.1", binary=True, float_fmt=".16e"):
     """Writes a Gmsh msh file."""
+    mesh = _convert_med_tags_to_gmsh(mesh)
     try:
         writer = _writers[fmt_version]
     except KeyError:

--- a/src/meshio/gmsh/main.py
+++ b/src/meshio/gmsh/main.py
@@ -1,10 +1,13 @@
 import pathlib
 import struct
+import numpy as np
+import copy
 
 from .._exceptions import ReadError, WriteError
 from .._helpers import register_format
 from . import _gmsh22, _gmsh40, _gmsh41
 from .common import _fast_forward_to_end_block
+from .._mesh import CellBlock, Mesh
 
 # Some mesh files out there have the version specified as version "2" when it really is
 # "2.2". Same with "4" vs "4.1".
@@ -111,3 +114,132 @@ register_format(
         "gmsh": lambda f, m, **kwargs: write(f, m, "4.1", **kwargs),
     },
 )
+def _convert_med_tags_to_gmsh(mesh):
+    is_med_data = (
+        "cell_tags" in mesh.cell_data
+        or "point_tags" in mesh.point_data
+        or any(k.startswith("med:") for k in mesh.field_data)
+        or hasattr(mesh, "cell_tags")
+        or hasattr(mesh, "point_tags")
+    )
+    if not is_med_data:
+        return mesh
+
+    mesh = copy.deepcopy(mesh)
+    # Mapping from group name to physical tag, and from family id to physical tag.
+    family_groups = getattr(mesh, "cell_tags", {})
+    group_names = sorted({n for names in family_groups.values() for n in names})
+    group_to_phys = {name: i for i, name in enumerate(group_names, start=1)}
+    fam_to_phys = {} # Mapping from family id to physical tag, for backward compatibility with older meshio versions that used cell_tags for this purpose.
+    for fam_id, names in family_groups.items():
+        if names:
+            fam_to_phys[int(fam_id)] = group_to_phys[names[0]]
+   
+    # Check if we have geometrical tags or cell_tags, and if we need to split cells based on them.
+    has_geom = "gmsh:geometrical" in mesh.cell_data
+    has_tags = "cell_tags" in mesh.cell_data
+
+    if has_geom:
+        split_data = mesh.cell_data["gmsh:geometrical"]
+    elif has_tags:
+        split_data = mesh.cell_data["cell_tags"]
+    else:
+        return _cleanup_med_fields(mesh, group_to_phys)
+
+    needs_split = any(
+        i < len(split_data)
+        and split_data[i] is not None
+        and len(np.unique(split_data[i])) > 1
+        for i in range(len(mesh.cells))
+    )
+    if not needs_split:
+        return _cleanup_med_fields(mesh, group_to_phys)
+
+    new_cells = []
+    new_geom = []
+    new_phys = []
+    entity_counter = 1
+
+    for i, cb in enumerate(mesh.cells):
+        if i >= len(split_data) or split_data[i] is None:
+            n = len(cb.data)
+            new_cells.append(cb)
+            new_geom.append(np.full(n, entity_counter, dtype=int))
+            new_phys.append(np.full(n, 0, dtype=int))
+            entity_counter += 1
+            continue
+
+        tags = np.asarray(split_data[i], dtype=int)
+        for utag in np.unique(tags):
+            mask = tags == utag
+            n = int(mask.sum())
+            new_cells.append(CellBlock(cb.type, cb.data[mask]))
+
+            if has_geom:
+                new_geom.append(np.full(n, int(utag), dtype=int))
+            else:
+                new_geom.append(np.full(n, entity_counter, dtype=int))
+
+            if has_geom and "gmsh:physical" in mesh.cell_data:
+                orig = mesh.cell_data["gmsh:physical"]
+                if i < len(orig) and orig[i] is not None:
+                    new_phys.append(np.asarray(orig[i], dtype=int)[mask])
+                else:
+                    new_phys.append(np.full(n, 0, dtype=int))
+            else:
+                phys = fam_to_phys.get(int(utag), 0)
+                new_phys.append(np.full(n, phys, dtype=int))
+
+            entity_counter += 1
+
+    point_data = {k: v for k, v in mesh.point_data.items() if k != "point_tags"}
+
+    if "gmsh:dim_tags" not in point_data:
+        n_pts = len(mesh.points)
+        dim_tags = np.zeros((n_pts, 2), dtype=int)
+        assigned = np.full(n_pts, False)
+        for ci, cb in enumerate(new_cells):
+            etag = int(new_geom[ci][0])
+            nodes = np.unique(cb.data)
+            new_nodes = nodes[~assigned[nodes]]
+            dim_tags[new_nodes, 0] = cb.dim
+            dim_tags[new_nodes, 1] = etag
+            assigned[nodes] = True
+        if not np.all(assigned):
+            rem = np.where(~assigned)[0]
+            dim_tags[rem, 0] = new_cells[0].dim if new_cells else 0
+            dim_tags[rem, 1] = int(new_geom[0][0]) if new_geom else 1
+        point_data["gmsh:dim_tags"] = dim_tags
+    else:
+        point_data["gmsh:dim_tags"] = np.asarray(
+            point_data["gmsh:dim_tags"], dtype=int
+        )
+
+    dim_val = new_cells[0].dim if new_cells else 2
+    field_data = {name: [tag, dim_val] for name, tag in group_to_phys.items()}
+
+    return Mesh(
+        mesh.points,
+        new_cells,
+        point_data=point_data,
+        cell_data={"gmsh:geometrical": new_geom, "gmsh:physical": new_phys},
+        field_data=field_data,
+    )
+
+
+def _cleanup_med_fields(mesh, group_to_phys):
+    if "cell_tags" in mesh.cell_data:
+        if "gmsh:physical" not in mesh.cell_data:
+            mesh.cell_data["gmsh:physical"] = mesh.cell_data["cell_tags"]
+        del mesh.cell_data["cell_tags"]
+    if "point_tags" in mesh.point_data:
+        del mesh.point_data["point_tags"]
+    mesh.field_data = {
+        k: v
+        for k, v in mesh.field_data.items()
+        if not k.startswith("med:")
+        and isinstance(v, (list, tuple))
+        and len(v) == 2
+        and isinstance(v[0], (int, np.integer))
+    }
+    return mesh

--- a/tests/test_gmsh.py
+++ b/tests/test_gmsh.py
@@ -179,3 +179,57 @@ def test_reference_file_with_entities(
     assert num_cells == ref_num_cells_in_cell_sets
 
     helpers.write_read(tmp_path, writer, meshio.gmsh.read, mesh, 1.0e-15)
+
+def test_convert_med_to_msh_preserves_metadata(tmp_path):
+    """La conversion MED → MSH doit préserver les tags et field_data."""
+    from meshio._mesh import CellBlock
+    from meshio.gmsh.main import _convert_med_tags_to_gmsh
+
+    points = np.array([
+        [0.0, 0.0],
+        [1.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [2.0, 0.0],
+        [2.0, 1.0],
+    ])
+
+    cells = [
+        CellBlock("triangle", np.array([[0, 1, 2], [1, 3, 2], [1, 4, 5], [1, 5, 3]])),
+    ]
+
+    # Simuler des données MED : 2 familles → 2 groupes géométriques
+    cell_data = {
+        "cell_tags": [np.array([-1, -1, -2, -2])],
+    }
+
+    mesh = meshio.Mesh(points, cells, cell_data=cell_data)
+    mesh.cell_tags = {-1: ["group_a"], -2: ["group_b"]}
+    mesh.point_tags = {}
+
+    # Conversion
+    converted = _convert_med_tags_to_gmsh(mesh)
+
+    # Doit avoir 2 blocs (split par cell_tags)
+    assert len(converted.cells) == 2
+    assert all(c.type == "triangle" for c in converted.cells)
+    assert len(converted.cells[0].data) == 2
+    assert len(converted.cells[1].data) == 2
+
+    # gmsh:geometrical doit exister avec des valeurs distinctes
+    assert "gmsh:geometrical" in converted.cell_data
+    geom_tags = [g[0] for g in converted.cell_data["gmsh:geometrical"]]
+    assert geom_tags[0] != geom_tags[1]
+
+    # gmsh:physical doit exister
+    assert "gmsh:physical" in converted.cell_data
+    phys_tags = [p[0] for p in converted.cell_data["gmsh:physical"]]
+    assert phys_tags[0] != phys_tags[1]  # group_a ≠ group_b
+
+    # gmsh:dim_tags doit exister
+    assert "gmsh:dim_tags" in converted.point_data
+    assert converted.point_data["gmsh:dim_tags"].shape == (6, 2)
+
+    # field_data doit être reconstruit
+    assert "group_a" in converted.field_data
+    assert "group_b" in converted.field_data


### PR DESCRIPTION
- Implement cell block splitting based on family IDs (cell_tags)
- Generate 'gmsh:geometrical' and 'gmsh:physical' tags for entity separation
- Reconstruct 'field_data' to preserve Physical Names in $PhysicalNames section
- Add 'gmsh:dim_tags' to populate $Entities and $Nodes correctly
- Add _cleanup_med_fields to remove MED-specific metadata before writing

This ensures that MED files with multiple families are correctly exported as separate physical groups in Gmsh instead of a single merged block.