### PR TITLE
feat(med): add extended data type support in field writer

### DIFF
--- a/src/meshio/med/_med.py
+++ b/src/meshio/med/_med.py
@@ -32,6 +32,21 @@ med_to_meshio_type = {v: k for k, v in meshio_to_med_type.items()}
 numpy_void_str = np.bytes_("")
 
 
+MED_FLOAT32 = 4
+MED_FLOAT64 = 6
+MED_INT32 = 24
+MED_INT64 = 26
+MED_INT = 28
+
+numpy_to_med_type = {
+    np.dtype("float32"): MED_FLOAT32,
+    np.dtype("float64"): MED_FLOAT64,
+    np.dtype("int32"): MED_INT32,
+    np.dtype("int64"): MED_INT64,
+    np.dtype("int"): MED_INT,
+}
+
+
 def read(filename):
     import h5py
 
@@ -377,7 +392,13 @@ def _write_data(
     try:  # a same MED field may contain fields of different natures
         field = fields.create_group(name)
         field.attrs.create("MAI", np.bytes_(mesh_name))
-        field.attrs.create("TYP", 6)  # MED_FLOAT64
+        numpy_to_med_type = {
+            np.dtype("float64"): 6,  # MED_FLOAT64
+            np.dtype("float32"): 4,  # MED_FLOAT32
+            np.dtype("int32"): 24,  # MED_INT32
+            np.dtype("int64"): 26,  # MED_INT64
+        }
+        field.attrs.create("TYP", numpy_to_med_type.get[data.dtype])  # MED_FLOAT64
         field.attrs.create("UNI", numpy_void_str)  # physical unit
         field.attrs.create("UNT", numpy_void_str)  # time unit
         n_components = 1 if data.ndim == 1 else data.shape[-1]


### PR DESCRIPTION
- Add global numpy_to_med_type mapping with FLOAT32, FLOAT64, INT32, INT64 and INT
- Remove redundant local mapping inside _write_data in favor of global one
- MED v4 supports multiple data types for result fields (not only FLOAT64)
- Allows memory optimization by using lighter types (e.g. FLOAT32, INT32)